### PR TITLE
解决微信登录过程调用时with方法传入参数无效的问题

### DIFF
--- a/src/Providers/WeChatProvider.php
+++ b/src/Providers/WeChatProvider.php
@@ -70,13 +70,14 @@ class WeChatProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getCodeFields($state = null)
     {
-        return [
+        $fields = [
             'appid'         => $this->clientId,
             'redirect_uri'  => $this->redirectUrl,
             'response_type' => 'code',
             'scope'         => $this->formatScopes($this->scopes, $this->scopeSeparator),
             'state'         => $state,
         ];
+        return array_merge($fields, $this->parameters);
     }
 
     /**


### PR DESCRIPTION
微信登录过程中，想要自定义传入state时，调用with方法传入的参数无效，发现实现这个方法时，忽略了parameters这个属性