### PR TITLE
修复无法使用自定义 Provider 问题

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -130,7 +130,8 @@ class SocialiteManager implements FactoryInterface
      */
     protected function createDriver($driver)
     {
-        if ($provider = $this->initialDrivers[$driver]) {
+        if (isset($this->initialDrivers[$driver])) {
+            $provider = $this->initialDrivers[$driver];
             $provider = __NAMESPACE__.'\\Providers\\'.$provider.'Provider';
 
             return $this->buildProvider($provider, $this->formatConfig($this->config->get($driver)));


### PR DESCRIPTION
使用自定义 Provider 时，因 initialDrivers 无相应的 key，会报 Undefined index 错误