### PR TITLE
添加微信企业号的 oauth登录

### DIFF
--- a/README-CoprWechat.md
+++ b/README-CoprWechat.md
@@ -1,0 +1,38 @@
+
+# 添加微信企业号ouath登录支持  Add Wechat Media Platform for Copr Version
+- 添加了一个新的Driver类: CorpWechat / Add a new driver into providers named CorpWechat
+- 这个库的主要目的是为了fork出overtrue/wechat的企业版铺平道路
+- 下面的代码示意是在laravel 下面写的, 其他框架或者纯php使用的时候可能需要做一些变通
+
+# 使用方法/Useage
+- 首先建议通读 <https://github.com/overtrue/socialite>
+- 代码示意:
+
+```php
+use Overtrue\Socialite\SocialiteManager as Socialite;
+private $socialite;
+public function __construct(){
+    $config = [
+        'corp-wechat' => [
+            'client_id' => "{公众号的corp_id}",
+            'client_secret' => "{公众号的secret}",
+            'redirect' => "oauth的回调地址, 以http开头, 如 http://www.xxx.com/oauth/callback",
+        ],
+        'longlive_access_token'=>false, //当这个值为false的时候, 本provider会自动获取, 当和其他例如overtrue/wechat一起使用的时候, 这里的值建议直接传入,否则会引起冲突
+   ];
+    $this->socialite = (new Socialite($config));
+}
+
+public function getAuth(){
+
+    $response = $this->socialite->driver('corp-wechat')->scopes(['snsapi_base'])->redirect();
+    return  $response;// or $response->send();     
+
+}
+
+public function getOauthcallback(){
+    $user = $this->socialite->driver('corp-wechat')->user();
+    print_r($user);
+
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 
-# 添加企业号登录支持/Add Wechat Media Platform for Copr Version
+# 添加微信企业号ouath登录支持  Add Wechat Media Platform for Copr Version
 - 添加了一个新的Driver类: CorpWechat / Add a new driver into providers named CorpWechat
+- 这个库的主要目的是为了fork出overtrue/wechat的企业版铺平道路
+- 下面的代码示意是在laravel 下面写的, 其他框架或者纯php使用的时候可能需要做一些变通
 
 # 使用方法/Useage
 - 首先建议通读 <https://github.com/overtrue/socialite>
-- 代码示意
-
+- 代码示意:
 
 ```php
 use Overtrue\Socialite\SocialiteManager as Socialite;

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 # 使用方法/Useage
 - 首先建议通读 <https://github.com/overtrue/socialite>
-
-
+- 代码示意
 
 
 ```php

--- a/README.md
+++ b/README.md
@@ -1,38 +1,239 @@
+# Socialite
 
-# 添加微信企业号ouath登录支持  Add Wechat Media Platform for Copr Version
-- 添加了一个新的Driver类: CorpWechat / Add a new driver into providers named CorpWechat
-- 这个库的主要目的是为了fork出overtrue/wechat的企业版铺平道路
-- 下面的代码示意是在laravel 下面写的, 其他框架或者纯php使用的时候可能需要做一些变通
+[![Build Status](https://travis-ci.org/overtrue/socialite.svg?branch=master)](https://travis-ci.org/overtrue/socialite)
+[![Latest Stable Version](https://poser.pugx.org/overtrue/socialite/v/stable.svg)](https://packagist.org/packages/overtrue/socialite)
+[![Latest Unstable Version](https://poser.pugx.org/overtrue/socialite/v/unstable.svg)](https://packagist.org/packages/overtrue/socialite)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/overtrue/socialite/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/overtrue/socialite/?branch=master)
+[![Total Downloads](https://poser.pugx.org/overtrue/socialite/downloads)](https://packagist.org/packages/overtrue/socialite)
+[![License](https://poser.pugx.org/overtrue/socialite/license)](https://packagist.org/packages/overtrue/socialite)
 
-# 使用方法/Useage
-- 首先建议通读 <https://github.com/overtrue/socialite>
-- 代码示意:
+Socialite is an OAuth2 Authentication tool. It is inspired by [laravel/socialite](https://github.com/laravel/socialite), You can easily use it in any PHP project.
+
+For Laravel 5: [overtrue/laravel-socialite](https://github.com/overtrue/laravel-socialite)
+
+# Requirement
+
+```
+PHP >= 5.4
+```
+# Installation
+
+```shell
+$ composer require "overtrue/socialite:~1.0"
+```
+
+# Usage
+
+`authorize.php`:
 
 ```php
-use Overtrue\Socialite\SocialiteManager as Socialite;
-private $socialite;
-public function __construct(){
-    $config = [
-        'corp-wechat' => [
-            'client_id' => "{公众号的corp_id}",
-            'client_secret' => "{公众号的secret}",
-            'redirect' => "oauth的回调地址, 以http开头, 如 http://www.xxx.com/oauth/callback",
-        ],
-        'longlive_access_token'=>false, //当这个值为false的时候, 本provider会自动获取, 当和其他例如overtrue/wechat一起使用的时候, 这里的值建议直接传入,否则会引起冲突
-   ];
-    $this->socialite = (new Socialite($config));
-}
+<?php
+use Overtrue\Socialite\SocialiteManager;
 
-public function getAuth(){
+$config = [
+    'github' => [
+        'client_id'     => 'your-app-id',
+        'client_secret' => 'your-app-secret',
+        'redirect'      => 'http://localhost/socialite/callback.php',
+    ],
+];
 
-    $response = $this->socialite->driver('corp-wechat')->scopes(['snsapi_base'])->redirect();
-    return  $response;// or $response->send();     
+$socialite = new SocialiteManager($config);
 
-}
+$response = $socialite->driver('github')->redirect();
 
-public function getOauthcallback(){
-    $user = $this->socialite->driver('corp-wechat')->user();
-    print_r($user);
+echo $response;// or $response->send();
+```
 
+`callback.php`:
+
+```php
+<?php
+
+// ...
+$user = $socialite->driver('github')->user();
+
+$user->getId();        // 1472352
+$user->getNickname();  // "overtrue"
+$user->getName();      // "安正超"
+$user->getEmail();     // "anzhengchao@gmail.com"
+...
+```
+
+### Configuration
+
+Now we support the following sites:
+
+`facebook`, `github`, `google`, `linkedin`, `weibo`, `qq`, `corp_wechat`, `wechat` and `douban`.
+
+Each drive uses the same configuration keys: `client_id`, `client_secret`, `redirect`.
+
+example:
+```
+...
+  'weibo' => [
+    'client_id'     => 'your-app-id',
+    'client_secret' => 'your-app-secret',
+    'redirect'      => 'http://localhost/socialite/callback.php',
+  ],
+...
+```
+
+### Scope
+
+Before redirecting the user, you may also set "scopes" on the request using the scope method. This method will overwrite all existing scopes:
+
+```php
+$response = $socialite->driver('github')
+                ->scopes(['scope1', 'scope2'])->redirect();
+
+```
+
+### Redirect URL
+
+You may also want to dynamic set `redirect`，you can use the following methods to change the `redirect` URL:
+
+```php
+$socialite->redirect($url);
+// or
+$socialite->withRedirectUrl($url)->redirect();
+// or
+$socialite->setRedirectUrl($url)->redirect();
+```
+
+> WeChat scopes:
+- `snsapi_base`, `snsapi_userinfo` - Used to Media Platform Authentication.
+- `snsapi_login` - Used to web Authentication.
+
+### Additional parameters
+
+To include any optional parameters in the request, call the with method with an associative array:
+
+```php
+$response = $socialite->driver('google')
+                    ->with(['hd' => 'example.com'])->redirect();
+```
+
+### User interface
+
+#### Standard user api:
+
+```php
+
+$user = $socialite->driver('weibo')->user();
+```
+
+```json
+{
+  "id": 1472352,
+  "nickname": "overtrue",
+  "name": "安正超",
+  "email": "anzhengchao@gmail.com",
+  "avatar": "https://avatars.githubusercontent.com/u/1472352?v=3",
+  "original": {
+    "login": "overtrue",
+    "id": 1472352,
+    "avatar_url": "https://avatars.githubusercontent.com/u/1472352?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/overtrue",
+    "html_url": "https://github.com/overtrue",
+    ...
+  },
+  "token": {
+    "access_token": "5b1dc56d64fffbd052359f032716cc4e0a1cb9a0",
+    "token_type": "bearer",
+    "scope": "user:email"
+  }
 }
 ```
+
+You can fetch the user attribute as a array key like this:
+
+```php
+$user['id'];        // 1472352
+$user['nickname'];  // "overtrue"
+$user['name'];      // "安正超"
+$user['email'];     // "anzhengchao@gmail.com"
+...
+```
+
+Or using method:
+
+```php
+$user->getId();
+$user->getNickname();
+$user->getName();
+$user->getEmail();
+$user->getAvatar();
+$user->getOriginal();
+$user->getToken();// or $user->getAccessToken()
+```
+
+#### Get original response from OAuth API
+
+The `$user->getOriginal()` method will return an array of the API raw response.
+
+#### Get access token Object
+
+You can get the access token instance of current session by call `$user->getToken()` or `$user->getAccessToken()` or `$user['token']` .
+
+
+### Get user with access token
+
+```php
+$accessToken = new AccessToken(['access_token' => $accessToken]);
+$user = $socialite->user($accessToken);
+```
+
+
+### Custom Session or Request instance.
+
+You can set the request with your custom `Request` instance which instanceof `Symfony\Component\HttpFoundation\Request`.
+
+
+```php
+
+$request = new Request(); // or use AnotherCustomRequest.
+
+$socialite = new SocialiteManager($config, $request);
+```
+
+Or set request to `SocialiteManager` instance:
+
+```php
+$socialite->setRequest($request);
+```
+
+You can get the request from `SocialiteManager` instance by `getRequest()`:
+
+```php
+$request = $socialite->getRequest();
+```
+
+#### Set custom session manager.
+
+By default, the `SocialiteManager` use `Symfony\Component\HttpFoundation\Session\Session` instance as session manager, you can change it as following lines:
+
+```php
+$session = new YourCustomSessionManager();
+$socialite->getRequest()->setSession($session);
+```
+
+> Your custom session manager must be implement the [`Symfony\Component\HttpFoundation\Session\SessionInterface`](http://api.symfony.com/3.0/Symfony/Component/HttpFoundation/Session/SessionInterface.html).
+
+Enjoy it! :heart:
+
+# Reference
+
+- [Google - OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect)
+- [Facebook - Graph API](https://developers.facebook.com/docs/graph-api)
+- [Linkedin - Authenticating with OAuth 2.0](https://developer.linkedin.com/docs/oauth2)
+- [微博 - OAuth 2.0 授权机制说明](http://open.weibo.com/wiki/%E6%8E%88%E6%9D%83%E6%9C%BA%E5%88%B6%E8%AF%B4%E6%98%8E)
+- [QQ - OAuth 2.0 登录QQ](http://wiki.connect.qq.com/oauth2-0%E7%AE%80%E4%BB%8B)
+- [微信公众平台 - OAuth文档](http://mp.weixin.qq.com/wiki/9/01f711493b5a02f24b04365ac5d8fd95.html)
+- [微信开放平台 - 网站应用微信登录开发指南](https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316505&token=&lang=zh_CN)
+- [豆瓣 - OAuth 2.0 授权机制说明](http://developers.douban.com/wiki/?title=oauth2)
+
+# License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,34 +1,30 @@
 
-# 添加企业号登录支持/Add Wechat Media Platform for Copr Version
-- 添加了一个新的Driver类: CorpWechat / Add a new driver into providers named CorpWechat
-# 使用方法/Useage
-- 首先建议通读 <https://github.com/overtrue/socialite>
-`
-use Overtrue\Socialite\SocialiteManager as Socialite;
-private $socialite;
-public function __construct(){
-    $config = [
-        'corp-wechat' => [
-            'client_id' => "{公众号的corp_id}",
-            'client_secret' => "{公众号的secret}",
-            'redirect' => "oauth的回调地址, 以http开头, 如 http://www.xxx.com/oauth/callback",
-        ],
-        'longlive_access_token'=>false, //当这个值为false的时候, 本provider会自动获取, 当和其他例如overtrue/wechat一起使用的时候, 这里的值建议直接传入,否则会引起冲突
-   ];
-    $this->socialite = (new Socialite($config));
-}
 
-public function getAuth(){
+```
+    use Overtrue\Socialite\SocialiteManager as Socialite;
+    private $socialite;
+    public function __construct(){
+        $config = [
+            'corp-wechat' => [
+                'client_id' => "{公众号的corp_id}",
+                'client_secret' => "{公众号的secret}",
+                'redirect' => "oauth的回调地址, 以http开头, 如 http://www.xxx.com/oauth/callback",
+            ],
+            'longlive_access_token'=>false, //当这个值为false的时候, 本provider会自动获取, 当和其他例如overtrue/wechat一起使用的时候, 这里的值建议直接传入,否则会引起冲突
+       ];
+        $this->socialite = (new Socialite($config));
+    }
 
-    $response = $this->socialite->driver('corp-wechat')->scopes(['snsapi_base'])->redirect();
-    return  $response;// or $response->send();     
+    public function getAuth(){
 
-}
+        $response = $this->socialite->driver('corp-wechat')->scopes(['snsapi_base'])->redirect();
+        return  $response;// or $response->send();     
 
-public function getOauthcallback(){
-    $user = $this->socialite->driver('corp-wechat')->user();
-    print_r($user);
+    }
 
-}
+    public function getOauthcallback(){
+        $user = $this->socialite->driver('corp-wechat')->user();
+        print_r($user);
 
-`
+    }
+```

--- a/README.md
+++ b/README.md
@@ -1,30 +1,37 @@
 
+# 添加企业号登录支持/Add Wechat Media Platform for Copr Version
+- 添加了一个新的Driver类: CorpWechat / Add a new driver into providers named CorpWechat
+# 使用方法/Useage
+- 首先建议通读 <https://github.com/overtrue/socialite>
 
-```
-    use Overtrue\Socialite\SocialiteManager as Socialite;
-    private $socialite;
-    public function __construct(){
-        $config = [
-            'corp-wechat' => [
-                'client_id' => "{公众号的corp_id}",
-                'client_secret' => "{公众号的secret}",
-                'redirect' => "oauth的回调地址, 以http开头, 如 http://www.xxx.com/oauth/callback",
-            ],
-            'longlive_access_token'=>false, //当这个值为false的时候, 本provider会自动获取, 当和其他例如overtrue/wechat一起使用的时候, 这里的值建议直接传入,否则会引起冲突
-       ];
-        $this->socialite = (new Socialite($config));
-    }
 
-    public function getAuth(){
 
-        $response = $this->socialite->driver('corp-wechat')->scopes(['snsapi_base'])->redirect();
-        return  $response;// or $response->send();     
 
-    }
+```php
+use Overtrue\Socialite\SocialiteManager as Socialite;
+private $socialite;
+public function __construct(){
+    $config = [
+        'corp-wechat' => [
+            'client_id' => "{公众号的corp_id}",
+            'client_secret' => "{公众号的secret}",
+            'redirect' => "oauth的回调地址, 以http开头, 如 http://www.xxx.com/oauth/callback",
+        ],
+        'longlive_access_token'=>false, //当这个值为false的时候, 本provider会自动获取, 当和其他例如overtrue/wechat一起使用的时候, 这里的值建议直接传入,否则会引起冲突
+   ];
+    $this->socialite = (new Socialite($config));
+}
 
-    public function getOauthcallback(){
-        $user = $this->socialite->driver('corp-wechat')->user();
-        print_r($user);
+public function getAuth(){
 
-    }
+    $response = $this->socialite->driver('corp-wechat')->scopes(['snsapi_base'])->redirect();
+    return  $response;// or $response->send();     
+
+}
+
+public function getOauthcallback(){
+    $user = $this->socialite->driver('corp-wechat')->user();
+    print_r($user);
+
+}
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 # 添加企业号登录支持/Add Wechat Media Platform for Copr Version
 - 添加了一个新的Driver类: CorpWechat / Add a new driver into providers named CorpWechat
+
 # 使用方法/Useage
 - 首先建议通读 <https://github.com/overtrue/socialite>
 

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -144,11 +144,11 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
         }
 
         return [
-            'access_token'=>$this->config['longlive_access_token'],
-            'code'=>$code,
+            'access_token' => $this->config['longlive_access_token'],
+            'code' => $code,
         ];
     }
-
+    
     /**
      * 原始微信oauth 应该是返回 access token + openid
      * 企业号因为用的是7200秒的, 所以需要支持从外部去获取access_token 不会冲突  要返回 userid.

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -67,6 +67,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
     {
         $query = http_build_query($this->getCodeFields($state), '', '&', $this->encodingType);
         $url = $url.'?'.$query.'#wechat_redirect';
+
         return $url;
     }
 
@@ -75,7 +76,6 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getCodeFields($state = null)
     {
-
         $result = array_merge([
             'appid' => $this->clientId,
             'redirect_uri' => $this->redirectUrl,
@@ -136,7 +136,6 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenFields($code = false)
     {
-
         if (!$code) {
             return [
                 'corpid' => $this->clientId,

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -33,7 +33,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
     protected $userBaseInfoApi = 'https://qyapi.weixin.qq.com/cgi-bin/user/getuserinfo';
     protected $userInfoApi = 'https://qyapi.weixin.qq.com/cgi-bin/user/get';
     protected $accessTokenApi = 'https://qyapi.weixin.qq.com/cgi-bin/gettoken';
-    protected $oauthApi= 'https://open.weixin.qq.com/connect/oauth2/authorize';
+    protected $oauthApi = 'https://open.weixin.qq.com/connect/oauth2/authorize';
 
     /**
      * {@inheritdoc}.
@@ -132,19 +132,19 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * 构建access_token 的参数列表, 分为两种情况一种是 获取access token, 另一种是直接获取userid
+     * 构建access_token 的参数列表, 分为两种情况一种是 获取access token, 另一种是直接获取userid.
      */
     protected function getTokenFields($code = false)
     {
 
-        if(!$code){
+        if (!$code){
             return [
                 'corpid' => $this->clientId,
                 'corpsecret' => $this->clientSecret,
             ];
         }
         return [
-            'access_token'=>$this->config['longlive_access_token'],
+						'access_token'=>$this->config['longlive_access_token'],
             'code'=>$code,
         ];    
     
@@ -153,12 +153,12 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
 
     /**
      * 原始微信oauth 应该是返回 access token + openid
-     * 企业号因为用的是7200秒的, 所以需要支持从外部去获取access_token 不会冲突  要返回 userid 
+     * 企业号因为用的是7200秒的, 所以需要支持从外部去获取access_token 不会冲突  要返回 userid.
      */
     public function getAccessToken($code)
     {
         //没有指定则自己获取
-        if(!$this->config['longlive_access_token']){
+        if (!$this->config['longlive_access_token']){
             $this->config['longlive_access_token'] = $this->getLongiveAccessToken();
         }
         $param = $this->getTokenFields($code);
@@ -166,24 +166,24 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
             'query' => $param,
         ]);
         $content = $response->getBody()->getContents();
-        $content = json_decode($content,true);
-        $content['access_token'] =  $this->config['longlive_access_token'];
+        $content = json_decode($content, true);
+        $content['access_token'] = $this->config['longlive_access_token'];
         $token = $this->parseAccessToken($content);
-        return $token;
 
+        return $token;
     }
     // !!应该尽量不要调用, 除非 单独与overture/wechat使用, 否则同时获取accesstoken, 会冲突
-    public function getLongiveAccessToken($forse_refresh = false){
+    public function getLongiveAccessToken($forse_refresh = false)
+		{
         $getTokenUrl = $this->getTokenUrl();
         $response = $this->getHttpClient()->get($getTokenUrl, [
             'query' => $this->getTokenFields(),
         ]);
         $content = $response->getBody()->getContents();
         $token = $this->parseAccessToken($content);
+
         return $token['access_token'];
     }
-
-   
 
     /**
      * Remove the fucking callback parentheses.

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -172,7 +172,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
     }
 
     // !!应该尽量不要调用, 除非 单独与overture/wechat使用, 否则同时获取accesstoken, 会冲突
-    public function getLongiveAccessToken($forse_refresh = false)
+    public function getLongiveAccessToken($force_refresh = false)
     {
         $getTokenUrl = $this->getTokenUrl();
         $response = $this->getHttpClient()->get($getTokenUrl, [

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * This file is part of the overtrue/socialite.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Overtrue\Socialite\Providers;
+
+use Overtrue\Socialite\AccessToken;
+use Overtrue\Socialite\AccessTokenInterface;
+use Overtrue\Socialite\InvalidArgumentException;
+use Overtrue\Socialite\ProviderInterface;
+use Overtrue\Socialite\User;
+
+/**
+ * Class WeChatProvider.
+ *
+ * @link http://mp.weixin.qq.com/wiki/9/01f711493b5a02f24b04365ac5d8fd95.html [WeChat - 公众平台OAuth文档]
+ * @link https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316505&token=&lang=zh_CN [网站应用微信登录开发指南]
+ */
+class CorpWechatProvider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * The base url of WeChat API.
+     *
+     * @var string
+     */
+    protected $baseUrl = 'https://api.weixin.qq.com/sns';
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected $openId;
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected $scopes = ['snsapi_login'];
+
+    /**
+     * Indicates if the session state should be utilized.
+     *
+     * @var bool
+     */
+    protected $stateless = true;
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected function getAuthUrl($state)
+    {
+        $path = 'oauth2/authorize';
+
+        $url = "https://open.weixin.qq.com/connect/{$path}";
+        // dd($url);
+        return $this->buildAuthUrlFromBase($url, $state);
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected function buildAuthUrlFromBase($url, $state)
+    {
+        $query = http_build_query($this->getCodeFields($state), '', '&', $this->encodingType);
+        return $url.'?'.$query.'#wechat_redirect';
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected function getCodeFields($state = null)
+    {
+
+        $result = array_merge([
+            'appid' => $this->clientId,
+            'redirect_uri' => $this->redirectUrl,
+            'response_type' => 'code',
+            'scope' => $this->formatScopes($this->scopes, $this->scopeSeparator),
+            'state' => $state ?: md5(time()),
+        ], $this->parameters);
+
+        // dd($result);
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected function getTokenUrl()
+    {
+        if ($this->isOpenPlatform()) {
+            return $this->baseUrl.'/oauth2/component/access_token';
+        }
+
+        return $this->baseUrl.'/oauth2/access_token';
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected function getUserByToken(AccessTokenInterface $token)
+    {
+        $scopes = explode(',', $token->getAttribute('scope', ''));
+
+        if (in_array('snsapi_base', $scopes)) {
+            return $token->toArray();
+        }
+
+        if (empty($token['openid'])) {
+            throw new InvalidArgumentException('openid of AccessToken is required.');
+        }
+
+        $response = $this->getHttpClient()->get($this->baseUrl.'/userinfo', [
+            'query' => [
+                'access_token' => $token->getToken(),
+                'openid' => $token['openid'],
+                'lang' => 'zh_CN',
+            ],
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return new User([
+            'id' => $this->arrayItem($user, 'openid'),
+            'name' => $this->arrayItem($user, 'nickname'),
+            'nickname' => $this->arrayItem($user, 'nickname'),
+            'avatar' => $this->arrayItem($user, 'headimgurl'),
+            'email' => null,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    protected function getTokenFields($code)
+    {
+        $base = [
+            'appid' => $this->clientId,
+            'code' => $code,
+            'grant_type' => 'authorization_code',
+        ];
+
+        if ($this->isOpenPlatform()) {
+            return array_merge($base, [
+                'component_appid' => $this->config->get('wechat.open_platform.app_id'),
+                'component_access_token' => $this->config->get('wechat.open_platform.access_token'),
+            ]);
+        }
+
+        return array_merge($base, [
+            'secret' => $this->clientSecret,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function getAccessToken($code)
+    {
+        $response = $this->getHttpClient()->get($this->getTokenUrl(), [
+            'query' => $this->getTokenFields($code),
+        ]);
+
+        return $this->parseAccessToken($response->getBody()->getContents());
+    }
+
+    /**
+     * Detect wechat open platform.
+     *
+     * @return mixed
+     */
+    protected function isOpenPlatform()
+    {
+        return $this->config->get('wechat.open_platform');
+    }
+
+    /**
+     * Remove the fucking callback parentheses.
+     *
+     * @param mixed $response
+     *
+     * @return string
+     */
+    protected function removeCallback($response)
+    {
+        if (strpos($response, 'callback') !== false) {
+            $lpos = strpos($response, '(');
+            $rpos = strrpos($response, ')');
+            $response = substr($response, $lpos + 1, $rpos - $lpos - 1);
+        }
+
+        return $response;
+    }
+}

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -170,7 +170,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
 
         return $token;
     }
-    
+
     // !!应该尽量不要调用, 除非 单独与overture/wechat使用, 否则同时获取accesstoken, 会冲突
     public function getLongiveAccessToken($forse_refresh = false)
     {

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -30,7 +30,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
      *
      * @var string
      */
-    protected $baseUrl = 'https://api.weixin.qq.com/sns';
+    protected $baseUrl = 'https://qyapi.weixin.qq.com/cgi-bin/user/getuserinfo';
 
     /**
      * {@inheritdoc}.
@@ -40,7 +40,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}.
      */
-    protected $scopes = ['snsapi_login'];
+    protected $scopes = ['snsapi_base'];
 
     /**
      * Indicates if the session state should be utilized.
@@ -84,7 +84,6 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
             'state' => $state ?: md5(time()),
         ], $this->parameters);
 
-        // dd($result);
         return $result;
     }
 

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -137,18 +137,17 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
     protected function getTokenFields($code = false)
     {
 
-        if (!$code){
+        if (!$code) {
             return [
                 'corpid' => $this->clientId,
                 'corpsecret' => $this->clientSecret,
             ];
         }
+
         return [
 						'access_token'=>$this->config['longlive_access_token'],
             'code'=>$code,
-        ];    
-    
-     
+        ];
     }
 
     /**
@@ -158,7 +157,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
     public function getAccessToken($code)
     {
         //没有指定则自己获取
-        if (!$this->config['longlive_access_token']){
+        if (!$this->config['longlive_access_token']) {
             $this->config['longlive_access_token'] = $this->getLongiveAccessToken();
         }
         $param = $this->getTokenFields($code);

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -148,7 +148,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
             'code' => $code,
         ];
     }
-    
+
     /**
      * 原始微信oauth 应该是返回 access token + openid
      * 企业号因为用的是7200秒的, 所以需要支持从外部去获取access_token 不会冲突  要返回 userid.
@@ -170,6 +170,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
 
         return $token;
     }
+    
     // !!应该尽量不要调用, 除非 单独与overture/wechat使用, 否则同时获取accesstoken, 会冲突
     public function getLongiveAccessToken($forse_refresh = false)
     {

--- a/src/Providers/CorpWeChatProvider.php
+++ b/src/Providers/CorpWeChatProvider.php
@@ -144,7 +144,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
         }
 
         return [
-						'access_token'=>$this->config['longlive_access_token'],
+            'access_token'=>$this->config['longlive_access_token'],
             'code'=>$code,
         ];
     }
@@ -172,7 +172,7 @@ class CorpWechatProvider extends AbstractProvider implements ProviderInterface
     }
     // !!应该尽量不要调用, 除非 单独与overture/wechat使用, 否则同时获取accesstoken, 会冲突
     public function getLongiveAccessToken($forse_refresh = false)
-		{
+    {
         $getTokenUrl = $this->getTokenUrl();
         $response = $this->getHttpClient()->get($getTokenUrl, [
             'query' => $this->getTokenFields(),

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -134,6 +134,7 @@ class SocialiteManager implements FactoryInterface
         if (isset($this->initialDrivers[$driver])) {
             $provider = $this->initialDrivers[$driver];
             $provider = __NAMESPACE__.'\\Providers\\'.$provider.'Provider';
+
             return $this->buildProvider($provider, $this->formatConfig($this->config->get($driver)));
         }
 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -55,7 +55,7 @@ class SocialiteManager implements FactoryInterface
             'weibo' => 'Weibo',
             'qq' => 'QQ',
             'wechat' => 'WeChat',
-            'corp-wechat' => 'CorpWeChat',
+            'corp_wechat' => 'CorpWeChat',
             'douban' => 'Douban',
     ];
 
@@ -134,7 +134,6 @@ class SocialiteManager implements FactoryInterface
         if (isset($this->initialDrivers[$driver])) {
             $provider = $this->initialDrivers[$driver];
             $provider = __NAMESPACE__.'\\Providers\\'.$provider.'Provider';
-
             return $this->buildProvider($provider, $this->formatConfig($this->config->get($driver)));
         }
 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -55,6 +55,7 @@ class SocialiteManager implements FactoryInterface
             'weibo' => 'Weibo',
             'qq' => 'QQ',
             'wechat' => 'WeChat',
+            'corp-wechat' => 'CorpWeChat',
             'douban' => 'Douban',
     ];
 


### PR DESCRIPTION
` $config = [
                    'corp-wechat' => [
                        // 'open_platform' => $pimple['config']['open_platform'],
                        'client_id' => config('corp-wechat.corp_id'),
                        'client_secret' => config('corp-wechat.secret'),
                        'redirect' => config('corp-wechat.oauth.callback'),
                    ],
                    'longlive_access_token'=>false,
                ];

        $this->socialite = (new Socialite($config));`

由于企业号那边会用到7200秒的那个access_token, 所以在构建config的时候添加一个longlive_access_token 可以传入. 这样的好处是之后写兼容overtrue/wechat的时候, 不会反复调用 getAccessToken() 引起冲突