### PR TITLE
企业微信provider中添加token url。

### DIFF
--- a/src/Providers/WeWorkProvider.php
+++ b/src/Providers/WeWorkProvider.php
@@ -126,7 +126,12 @@ class WeWorkProvider extends AbstractProvider implements ProviderInterface
 
     protected function getTokenUrl()
     {
-        return null;
+        $queries = [
+            'corpid'     => $this->clientId,
+            'corpsecret' => $this->clientSecret,
+        ];
+
+        return 'https://qyapi.weixin.qq.com/cgi-bin/gettoken?'.http_build_query($queries);
     }
 
     /**


### PR DESCRIPTION
缺少token url时，无法获取user信息。