### PR TITLE
解决微信公众平台网页授权两次或多次重定响应问题

### DIFF
--- a/src/Providers/WeChatProvider.php
+++ b/src/Providers/WeChatProvider.php
@@ -142,6 +142,7 @@ class WeChatProvider extends AbstractProvider implements ProviderInterface
             'response_type' => 'code',
             'scope' => $this->formatScopes($this->scopes, $this->scopeSeparator),
             'state' => $state ?: md5(time()),
+            'connect_redirect' => 1,
         ], $this->parameters);
     }
 


### PR DESCRIPTION
在 Android 设备上进行微信公众号授权登录时，会遇到多次重定向的问题。在网上找到该解决方案，经测试可行。

## 测试流程
### 1 次重定向
1. 给库加上代码 `'connect_redirect' => 1,`
2. 清除微信浏览器缓存：使用 http://debugx5.qq.com/ 清除缓存，并退出微信
3. 登录微信，进入登录页，走授权流程，查看 nginx 的 access.log，**只有 1 次授权回调**

![qq 20180326193121](https://user-images.githubusercontent.com/2800700/37904009-c0f9fcd8-312c-11e8-90e6-051f3314644b.png)

### 2 次重定向
1. 去掉代码 `'connect_redirect' => 1,`
2. 清除微信浏览器缓存：使用 http://debugx5.qq.com/ 清除缓存，并退出微信
3. 登录微信，进入登录页，走授权流程，查看 nginx 的 access.log，**出现 2 次授权回调**

![qq 20180326193241](https://user-images.githubusercontent.com/2800700/37903991-aba8ab5e-312c-11e8-94c2-8dd1c4b30027.png)

截图中的请求，带 code 参数的为 微信的授权回调请求。
在 iOS 上按上述流程测试，都是 1 次重定向。

参考网址：
https://my.oschina.net/u/3087202/blog/1649210
https://blog.csdn.net/qq_34207892/article/details/79578698
