### PR TITLE
Take all available fields provided by WeChat.

### DIFF
--- a/src/Providers/WeChatProvider.php
+++ b/src/Providers/WeChatProvider.php
@@ -196,6 +196,10 @@ class WeChatProvider extends AbstractProvider implements ProviderInterface
             'name' => $this->arrayItem($user, 'nickname'),
             'nickname' => $this->arrayItem($user, 'nickname'),
             'avatar' => $this->arrayItem($user, 'headimgurl'),
+            'sex' => $this->arrayItem($user, 'sex'),
+            'province' => $this->arrayItem($user, 'province'),
+            'city' => $this->arrayItem($user, 'city'),
+            'country' => $this->arrayItem($user, 'country'),
             'email' => null,
         ]);
     }


### PR DESCRIPTION
See https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1421140842

Missing `sex`, `province`, `city` and `country`.