### PR TITLE
解决常驻内存swoole 环境下运行，oauth授权提示找不到 code 问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "overtrue/socialite",
+    "name": "ndj888/socialite",
     "description": "A collection of OAuth 2 packages that extracts from laravel/socialite.",
     "keywords": ["OAuth", "social", "login", "Weibo", "WeChat", "QQ"],
     "autoload": {

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -114,7 +114,7 @@ class SocialiteManager implements FactoryInterface
         }
         // swoole constrcut request bug
         // there set request
-        $this->drivers[$driver]->setRequest($this->request);
+        $this->drivers[$driver]->setRequest(request());
         return $this->drivers[$driver];
     }
 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -112,7 +112,9 @@ class SocialiteManager implements FactoryInterface
         if (!isset($this->drivers[$driver])) {
             $this->drivers[$driver] = $this->createDriver($driver);
         }
-
+        // swoole constrcut request bug
+        // there set request
+        $this->drivers[$driver]->setRequest($this->request);
         return $this->drivers[$driver];
     }
 


### PR DESCRIPTION
1、系统环境 centos + php 7.2.10 + swoole 4.2.1
2、使用框架 laravels 适配swoole 版本的 laravel
3、出现错误 [2018-11-09 13:47:35] local.ERROR: Authorize Failed: {"errcode":41008,"errmsg":"missing code, hints: [ req_id: tXGFsa04552014 ]"} {"exception":"[object] (Overtrue\\Socialite\\AuthorizeFailedException(code: -1): Authorize Failed: {\"errcode\":41008,\"errmsg\":\"missing code, hints: [ req_id: tXGFsa04552014 ]\"} at /opt/project/vendor/overtrue/socialite/src/Providers/AbstractProvider.php:446)
4、原因分析：文件/overtrue/socialite/src/Providers/AbstractProvider.php request 实例由构造函数传入，fpm模式下不会有问题，swoole环境下，由于构造方法仅执行一次，故需要在文件overtrue/socialite/src/SocialiteManager.php line:115 driver 实例获得方法，返回实例前调用 setRequest方法，将更新的$request 传入