### PR TITLE
change getAuthUrl method to public

### DIFF
--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -131,7 +131,7 @@ abstract class AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    abstract protected function getAuthUrl($state);
+    abstract public function getAuthUrl($state);
 
     /**
      * Get the token URL for the provider.
@@ -538,7 +538,7 @@ abstract class AbstractProvider implements ProviderInterface
      *
      * @return string|bool
      */
-    protected function makeState()
+    public function makeState()
     {
         if (!$this->request->hasSession()) {
             return false;

--- a/src/Providers/DouYinProvider.php
+++ b/src/Providers/DouYinProvider.php
@@ -35,7 +35,7 @@ class DouYinProvider extends AbstractProvider implements ProviderInterface
      *
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase($this->baseUrl.'/platform/oauth/connect', $state);
     }

--- a/src/Providers/DoubanProvider.php
+++ b/src/Providers/DoubanProvider.php
@@ -25,7 +25,7 @@ class DoubanProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}.
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://www.douban.com/service/auth2/auth', $state);
     }

--- a/src/Providers/FacebookProvider.php
+++ b/src/Providers/FacebookProvider.php
@@ -60,7 +60,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://www.facebook.com/'.$this->version.'/dialog/oauth', $state);
     }

--- a/src/Providers/GitHubProvider.php
+++ b/src/Providers/GitHubProvider.php
@@ -31,7 +31,7 @@ class GitHubProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://github.com/login/oauth/authorize', $state);
     }

--- a/src/Providers/GoogleProvider.php
+++ b/src/Providers/GoogleProvider.php
@@ -43,7 +43,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://accounts.google.com/o/oauth2/v2/auth', $state);
     }

--- a/src/Providers/LinkedinProvider.php
+++ b/src/Providers/LinkedinProvider.php
@@ -32,7 +32,7 @@ class LinkedinProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://www.linkedin.com/oauth/v2/authorization', $state);
     }

--- a/src/Providers/OutlookProvider.php
+++ b/src/Providers/OutlookProvider.php
@@ -33,7 +33,7 @@ class OutlookProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://login.microsoftonline.com/common/oauth2/v2.0/authorize', $state);
     }

--- a/src/Providers/QQProvider.php
+++ b/src/Providers/QQProvider.php
@@ -71,7 +71,7 @@ class QQProvider extends AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase($this->baseUrl.'/oauth2.0/authorize', $state);
     }

--- a/src/Providers/TaobaoProvider.php
+++ b/src/Providers/TaobaoProvider.php
@@ -74,7 +74,7 @@ class TaobaoProvider extends AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase($this->baseUrl.'/authorize', $state);
     }

--- a/src/Providers/WeChatProvider.php
+++ b/src/Providers/WeChatProvider.php
@@ -105,7 +105,7 @@ class WeChatProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}.
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         $path = 'oauth2/authorize';
 

--- a/src/Providers/WeWorkProvider.php
+++ b/src/Providers/WeWorkProvider.php
@@ -73,7 +73,7 @@ class WeWorkProvider extends AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         // 网页授权登录
         if (!empty($this->scopes)) {

--- a/src/Providers/WeiboProvider.php
+++ b/src/Providers/WeiboProvider.php
@@ -57,7 +57,7 @@ class WeiboProvider extends AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase($this->baseUrl.'/oauth2/authorize', $state);
     }

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -125,7 +125,7 @@ class OAuthTwoTestProviderStub extends AbstractProvider
 {
     public $http;
 
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return 'http://auth.url';
     }


### PR DESCRIPTION
Change getAuthUrl method to public, sometimes I need get redirct url but not redirct to it, example use electron develop PC app. So I change the method to public. Can use like this:

```php

$wechatDriver = Socialite::driver('wechat');
$url = $wechatDriver->getAuthUrl($wechatDriver->makeState());

```