### PR TITLE
Without session

### DIFF
--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -252,8 +252,10 @@ abstract class AbstractProvider implements ProviderInterface
     public function setAutoSaveState(bool $autoSaveState)
     {
         $this->autoSaveState = $autoSaveState;
+
         return $this;
     }
+
     /**
      * @param \Overtrue\Socialite\AccessTokenInterface $accessToken
      *
@@ -428,6 +430,7 @@ abstract class AbstractProvider implements ProviderInterface
         }
 
         $state = $this->request->getSession()->get('state');
+
         return !(strlen($state) > 0 && $this->request->get('state') === $state);
     }
 

--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -102,6 +102,12 @@ abstract class AbstractProvider implements ProviderInterface
     protected $stateless = false;
 
     /**
+     * Indicates if the state should be save to session.
+     *
+     * @var bool
+     */
+    protected $autoSaveState = true;
+    /**
      * The options for guzzle\client.
      *
      * @var array
@@ -236,6 +242,18 @@ abstract class AbstractProvider implements ProviderInterface
         return $this->redirectUrl;
     }
 
+    /**
+     * Set autoSaveState .
+     *
+     * @param bool $autoSaveState
+     *
+     * @return $this
+     */
+    public function setAutoSaveState(bool $autoSaveState)
+    {
+        $this->autoSaveState = $autoSaveState;
+        return $this;
+    }
     /**
      * @param \Overtrue\Socialite\AccessTokenInterface $accessToken
      *
@@ -410,7 +428,6 @@ abstract class AbstractProvider implements ProviderInterface
         }
 
         $state = $this->request->getSession()->get('state');
-
         return !(strlen($state) > 0 && $this->request->get('state') === $state);
     }
 
@@ -540,11 +557,15 @@ abstract class AbstractProvider implements ProviderInterface
      */
     public function makeState()
     {
+        $state = sha1(uniqid(mt_rand(1, 1000000), true));
+        if (!$this->autoSaveState) {
+            return $state;
+        }
+
         if (!$this->request->hasSession()) {
             return false;
         }
 
-        $state = sha1(uniqid(mt_rand(1, 1000000), true));
         $session = $this->request->getSession();
 
         if (is_callable([$session, 'put'])) {

--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -131,7 +131,7 @@ abstract class AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    abstract protected function getAuthUrl($state);
+    abstract public function getAuthUrl($state);
 
     /**
      * Get the token URL for the provider.
@@ -538,7 +538,7 @@ abstract class AbstractProvider implements ProviderInterface
      *
      * @return string|bool
      */
-    protected function makeState()
+    public function makeState()
     {
         if (!$this->request->hasSession()) {
             return false;

--- a/src/Providers/DouYinProvider.php
+++ b/src/Providers/DouYinProvider.php
@@ -35,7 +35,7 @@ class DouYinProvider extends AbstractProvider implements ProviderInterface
      *
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase($this->baseUrl.'/platform/oauth/connect', $state);
     }

--- a/src/Providers/DoubanProvider.php
+++ b/src/Providers/DoubanProvider.php
@@ -25,7 +25,7 @@ class DoubanProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}.
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://www.douban.com/service/auth2/auth', $state);
     }

--- a/src/Providers/FacebookProvider.php
+++ b/src/Providers/FacebookProvider.php
@@ -60,7 +60,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://www.facebook.com/'.$this->version.'/dialog/oauth', $state);
     }

--- a/src/Providers/GitHubProvider.php
+++ b/src/Providers/GitHubProvider.php
@@ -31,7 +31,7 @@ class GitHubProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://github.com/login/oauth/authorize', $state);
     }

--- a/src/Providers/GoogleProvider.php
+++ b/src/Providers/GoogleProvider.php
@@ -43,7 +43,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://accounts.google.com/o/oauth2/v2/auth', $state);
     }

--- a/src/Providers/LinkedinProvider.php
+++ b/src/Providers/LinkedinProvider.php
@@ -32,7 +32,7 @@ class LinkedinProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://www.linkedin.com/oauth/v2/authorization', $state);
     }

--- a/src/Providers/OutlookProvider.php
+++ b/src/Providers/OutlookProvider.php
@@ -33,7 +33,7 @@ class OutlookProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://login.microsoftonline.com/common/oauth2/v2.0/authorize', $state);
     }

--- a/src/Providers/QQProvider.php
+++ b/src/Providers/QQProvider.php
@@ -71,7 +71,7 @@ class QQProvider extends AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase($this->baseUrl.'/oauth2.0/authorize', $state);
     }

--- a/src/Providers/TaobaoProvider.php
+++ b/src/Providers/TaobaoProvider.php
@@ -74,7 +74,7 @@ class TaobaoProvider extends AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase($this->baseUrl.'/authorize', $state);
     }

--- a/src/Providers/WeChatProvider.php
+++ b/src/Providers/WeChatProvider.php
@@ -105,7 +105,7 @@ class WeChatProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}.
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         $path = 'oauth2/authorize';
 

--- a/src/Providers/WeWorkProvider.php
+++ b/src/Providers/WeWorkProvider.php
@@ -73,7 +73,7 @@ class WeWorkProvider extends AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         // 网页授权登录
         if (!empty($this->scopes)) {

--- a/src/Providers/WeiboProvider.php
+++ b/src/Providers/WeiboProvider.php
@@ -57,7 +57,7 @@ class WeiboProvider extends AbstractProvider implements ProviderInterface
      *
      * @return string
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase($this->baseUrl.'/oauth2/authorize', $state);
     }

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -125,7 +125,7 @@ class OAuthTwoTestProviderStub extends AbstractProvider
 {
     public $http;
 
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return 'http://auth.url';
     }


### PR DESCRIPTION
支持了用jwt(没有session)验证的网站使用。support jwt or other without session auth 
### change:
 - 修改了`getAuthUrl` 为公开的 change `getAuthUrl` method to public 
 - 修改了`makeState`为公开  change `makeState` method to public
- 修改了`autoSaveState` 是否自动保存state到session的标识变量， 如果没有session就改这个变量为false

### useage:
通过生成的state，进行登录
```php
        // 展示登录二维码
        $state = $driver->makeState();
        $url = $driver->getAuthUrl($state);
        // 将url 和state返回给前端
        return $this->success([
            'url' => $url,
            'state' => $state,
        ]);
```

```php
    // 回调时，获取user, 
    $state = $request->get('state');
    $driverTag = 'qq';
    $driver = Socialite::driver($driverTag);

    $user = $driver->stateless()->user();
```
