### PR TITLE
Support PHP 5.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 # Requirement
 
 ```
-PHP >= 7.0
+PHP >= 5.6
 ```
 # Installation
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   },
   "require": {
-    "php": ">=7.0",
+    "php": ">=5.6",
     "guzzlehttp/guzzle": "~5.0|~6.0",
     "symfony/http-foundation": "^2.7|^3.0|^4.0|^5.0",
     "ext-json": "*"

--- a/src/User.php
+++ b/src/User.php
@@ -181,6 +181,6 @@ class User implements ArrayAccess, UserInterface, JsonSerializable, \Serializabl
      */
     public function unserialize($serialized)
     {
-        $this->attributes = \unserialize($serialized) ?? [];
+        $this->attributes = unserialize($serialized) ?: [];
     }
 }


### PR DESCRIPTION
* `GoogleProvider` under `1.3.0` uses legacy APIs, no longer supported on new Google Cloud projects.
* `User@unserialize` is the only usage of PHP 7 syntax.