### PR TITLE
Typed property Overtrue\Socialite\Providers\WeChat::$openid must not …

### DIFF
--- a/src/Providers/WeChat.php
+++ b/src/Providers/WeChat.php
@@ -18,7 +18,7 @@ class WeChat extends Base
     protected array $scopes = ['snsapi_login'];
     protected bool $withCountryCode = false;
     protected ?array $component = null;
-    protected ?string $openid;
+    protected ?string $openid = null;
 
     public function __construct(array $config)
     {


### PR DESCRIPTION
Typed property Overtrue\Socialite\Providers\WeChat::$openid must not be accessed before initialization