### PR TITLE
修复 Wework::getUserById 方法重复json_decode问题

### DIFF
--- a/src/Providers/WeWork.php
+++ b/src/Providers/WeWork.php
@@ -173,7 +173,7 @@ class WeWork extends Base
             throw new AuthorizeFailedException('Failed to get user:' . $response['errmsg'] ?? 'Unknown.', $response);
         }
 
-        return \json_decode($response->getBody(), true) ?? [];
+        return $response;
     }
 
     /**

--- a/src/Providers/WeWork.php
+++ b/src/Providers/WeWork.php
@@ -141,8 +141,10 @@ class WeWork extends Base
 
         $response = \json_decode($response->getBody(), true) ?? [];
 
-        if (($response['errcode'] ?? 1) > 0 || empty($response['UserId'])) {
+        if (($response['errcode'] ?? 1) > 0 || (empty($response['UserId']) && empty($response['OpenId']))) {
             throw new AuthorizeFailedException('Failed to get user openid:' . $response['errmsg'] ?? 'Unknown.', $response);
+        } else if (empty($response['UserId'])) {
+            $this->detailed = false;
         }
 
         return $response;


### PR DESCRIPTION
关联issue：[https://github.com/w7corp/easywechat/issues/1949](https://github.com/w7corp/easywechat/issues/1949)