### PR TITLE
大量代码修型及可能的bug修正:

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -3,8 +3,9 @@
 namespace Overtrue\Socialite;
 
 use ArrayAccess;
+use JsonSerializable;
 
-class Config implements ArrayAccess, \JsonSerializable
+class Config implements ArrayAccess, JsonSerializable
 {
     protected array $config;
 
@@ -24,8 +25,8 @@ class Config implements ArrayAccess, \JsonSerializable
             return $config[$key];
         }
 
-        foreach (explode('.', $key) as $segment) {
-            if (!is_array($config) || !array_key_exists($segment, $config)) {
+        foreach (\explode('.', $key) as $segment) {
+            if (!\is_array($config) || !\array_key_exists($segment, $config)) {
                 return $default;
             }
             $config = $config[$segment];
@@ -36,18 +37,18 @@ class Config implements ArrayAccess, \JsonSerializable
 
     public function set(string $key, $value): mixed
     {
-        $keys = explode('.', $key);
+        $keys = \explode('.', $key);
         $config = &$this->config;
 
-        while (count($keys) > 1) {
-            $key = array_shift($keys);
-            if (!isset($config[$key]) || !is_array($config[$key])) {
+        while (\count($keys) > 1) {
+            $key = \array_shift($keys);
+            if (!isset($config[$key]) || !\is_array($config[$key])) {
                 $config[$key] = [];
             }
             $config = &$config[$key];
         }
 
-        $config[array_shift($keys)] = $value;
+        $config[\array_shift($keys)] = $value;
 
         return $config;
     }
@@ -59,7 +60,7 @@ class Config implements ArrayAccess, \JsonSerializable
 
     public function offsetExists(mixed $offset): bool
     {
-        return array_key_exists($offset, $this->config);
+        return \array_key_exists($offset, $this->config);
     }
 
     public function offsetGet(mixed $offset): mixed

--- a/src/Contracts/FactoryInterface.php
+++ b/src/Contracts/FactoryInterface.php
@@ -2,12 +2,12 @@
 
 namespace Overtrue\Socialite\Contracts;
 
+const ABNF_APP_ID = 'app_id';
+const ABNF_APP_SECRET = 'app_secret';
+const ABNF_OPEN_ID = 'open_id';
+const ABNF_TOKEN = 'token';
+
 interface FactoryInterface
 {
-    /**
-     * @param string $driver
-     *
-     * @return \Overtrue\Socialite\Contracts\ProviderInterface
-     */
     public function create(string $driver): ProviderInterface;
 }

--- a/src/Contracts/ProviderInterface.php
+++ b/src/Contracts/ProviderInterface.php
@@ -2,6 +2,45 @@
 
 namespace Overtrue\Socialite\Contracts;
 
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.1 */
+const RFC6749_ABNF_CLIENT_ID = 'client_id';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.2 */
+const RFC6749_ABNF_CLIENT_SECRET = 'client_secret';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.3 */
+const RFC6749_ABNF_RESPONSE_TYPE = 'response_type';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.4 */
+const RFC6749_ABNF_SCOPE = 'scope';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.5 */
+const RFC6749_ABNF_STATE = 'state';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.6 */
+const RFC6749_ABNF_REDIRECT_URI = 'redirect_uri';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.7 */
+const RFC6749_ABNF_ERROR = 'error';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.8 */
+const RFC6749_ABNF_ERROR_DESCRIPTION = 'error_description';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.9 */
+const RFC6749_ABNF_ERROR_URI = 'error_uri';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.10 */
+const RFC6749_ABNF_GRANT_TYPE = 'grant_type';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.11 */
+const RFC6749_ABNF_CODE = 'code';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.12 */
+const RFC6749_ABNF_ACCESS_TOKEN = 'access_token';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.13 */
+const RFC6749_ABNF_TOKEN_TYPE = 'token_type';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.14 */
+const RFC6749_ABNF_EXPIRES_IN = 'expires_in';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.15 */
+const RFC6749_ABNF_USERNAME = 'username';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.16 */
+const RFC6749_ABNF_PASSWORD = 'password';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.17 */
+const RFC6749_ABNF_REFRESH_TOKEN = 'refresh_token';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3 */
+const RFC6749_ABNF_AUTHORATION_CODE = 'authorization_code';
+/** @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2 */
+const RFC6749_ABNF_CLIENT_CREDENTIALS = 'client_credentials';
+
 interface ProviderInterface
 {
     public function redirect(?string $redirectUrl = null): string;
@@ -10,7 +49,10 @@ interface ProviderInterface
 
     public function userFromToken(string $token): UserInterface;
 
-    public function withState(string $state): ProviderInterface;
+    public function withState(string $state): self;
 
-    public function scopes(array $scopes): ProviderInterface;
+    /**
+     * @param string[] $scopes
+     */
+    public function scopes(array $scopes): self;
 }

--- a/src/Contracts/UserInterface.php
+++ b/src/Contracts/UserInterface.php
@@ -2,6 +2,12 @@
 
 namespace Overtrue\Socialite\Contracts;
 
+const ABNF_ID = 'id';
+const ABNF_NAME = 'name';
+const ABNF_NICKNAME = 'nickname';
+const ABNF_EMAIL = 'email';
+const ABNF_AVATAR = 'avatar';
+
 interface UserInterface
 {
     public function getId(): mixed;
@@ -19,4 +25,18 @@ interface UserInterface
     public function getRefreshToken(): ?string;
 
     public function getExpiresIn(): ?int;
+
+    public function getProvider(): ProviderInterface;
+
+    public function setRefreshToken(?string $refreshToken): self;
+
+    public function setExpiresIn(int $expiresIn): self;
+
+    public function setTokenResponse(array $response): self;
+
+    public function setProvider(ProviderInterface $provider): self;
+
+    public function setRaw(array $user): self;
+
+    public function setAccessToken(string $token): self;
 }

--- a/src/Exceptions/FeiShu/InvalidTicketException.php
+++ b/src/Exceptions/FeiShu/InvalidTicketException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Overtrue\Socialite\Exceptions\FeiShu;
+
+use Overtrue\Socialite\Exceptions;
+
+class InvalidTicketException extends Exceptions\Exception
+{
+}

--- a/src/Exceptions/Feishu/InvalidTicketException.php
+++ b/src/Exceptions/Feishu/InvalidTicketException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Overtrue\Socialite\Exceptions\Feishu;
-
-use Overtrue\Socialite\Exceptions\Exception;
-
-class InvalidTicketException extends Exception
-{
-}

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -2,7 +2,7 @@
 
 namespace Overtrue\Socialite\Exceptions;
 
-class InvalidArgumentException extends Exception
+class InvalidArgumentException extends \InvalidArgumentException
 {
     //
 }

--- a/src/Providers/Azure.php
+++ b/src/Providers/Azure.php
@@ -4,12 +4,13 @@ namespace Overtrue\Socialite\Providers;
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\UserInterface;
+use Overtrue\Socialite\Contracts;
 use Overtrue\Socialite\User;
 
 class Azure extends Base
 {
     public const NAME = 'azure';
+
     protected array $scopes = ['User.Read'];
     protected string $scopeSeparator = ' ';
 
@@ -20,7 +21,7 @@ class Azure extends Base
 
     protected function getBaseUrl(): string
     {
-        return 'https://login.microsoftonline.com/'.$this->config["tenant"];
+        return 'https://login.microsoftonline.com/' . $this->config['tenant'];
     }
 
     protected function getTokenUrl(): string
@@ -28,45 +29,43 @@ class Azure extends Base
         return $this->getBaseUrl() . '/oauth2/v2.0/token';
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
     protected function getUserByToken(string $token, ?array $query = []): array
     {
         $response = $this->getHttpClient()->get(
             'https://graph.microsoft.com/v1.0/me',
             ['headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => 'Bearer '.$token,
+                'Authorization' => 'Bearer ' . $token,
             ],
             ]
         );
 
-        return \json_decode($response->getBody()->getContents(), true) ?? [];
+        return $this->fromJsonBody($response);
     }
 
     #[Pure]
-    protected function mapUserToObject(array $user): UserInterface
+    protected function mapUserToObject(array $user): Contracts\UserInterface
     {
         return new User([
-            'id' => $user['id'] ?? null,
-            'nickname' => null,
-            'name' => $user['displayName'] ?? null,
-            'email' => $user['userPrincipalName'] ?? null,
-            'avatar' => null,
+            Contracts\ABNF_ID => $user[Contracts\ABNF_ID] ?? null,
+            Contracts\ABNF_NICKNAME => null,
+            Contracts\ABNF_NAME => $user['displayName'] ?? null,
+            Contracts\ABNF_EMAIL => $user['userPrincipalName'] ?? null,
+            Contracts\ABNF_AVATAR => null,
         ]);
     }
 
     #[ArrayShape([
-        'client_id' => "\null|string",
-        'client_secret' => "\null|string",
-        'code' => "string",
-        'redirect_uri' => "mixed"
+        Contracts\RFC6749_ABNF_CLIENT_ID => 'null|string',
+        Contracts\RFC6749_ABNF_CLIENT_SECRET => 'null|string',
+        Contracts\RFC6749_ABNF_CODE => 'string',
+        Contracts\RFC6749_ABNF_REDIRECT_URI => 'null|string',
+        Contracts\RFC6749_ABNF_GRANT_TYPE => 'string',
     ])]
     protected function getTokenFields(string $code): array
     {
         return parent::getTokenFields($code) + [
-            'grant_type' => 'authorization_code',
+            Contracts\RFC6749_ABNF_GRANT_TYPE => Contracts\RFC6749_ABNF_AUTHORATION_CODE,
         ];
     }
 }

--- a/src/Providers/Base.php
+++ b/src/Providers/Base.php
@@ -3,15 +3,15 @@
 namespace Overtrue\Socialite\Providers;
 
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Utils;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\StreamInterface;
 use JetBrains\PhpStorm\ArrayShape;
 use Overtrue\Socialite\Config;
-use Overtrue\Socialite\Contracts\ProviderInterface;
-use Overtrue\Socialite\Contracts\UserInterface;
-use Overtrue\Socialite\Exceptions\AuthorizeFailedException;
-use Overtrue\Socialite\Exceptions\MethodDoesNotSupportException;
+use Overtrue\Socialite\Contracts;
+use Overtrue\Socialite\Exceptions;
 
-abstract class Base implements ProviderInterface
+abstract class Base implements Contracts\ProviderInterface
 {
     public const NAME = null;
 
@@ -24,9 +24,9 @@ abstract class Base implements ProviderInterface
     protected GuzzleClient $httpClient;
     protected array        $guzzleOptions = [];
     protected int          $encodingType = PHP_QUERY_RFC1738;
-    protected string       $expiresInKey = 'expires_in';
-    protected string       $accessTokenKey = 'access_token';
-    protected string       $refreshTokenKey = 'refresh_token';
+    protected string       $expiresInKey = Contracts\RFC6749_ABNF_EXPIRES_IN;
+    protected string       $accessTokenKey = Contracts\RFC6749_ABNF_ACCESS_TOKEN;
+    protected string       $refreshTokenKey = Contracts\RFC6749_ABNF_REFRESH_TOKEN;
 
     public function __construct(array $config)
     {
@@ -35,23 +35,23 @@ abstract class Base implements ProviderInterface
         // set scopes
         if ($this->config->has('scopes') && is_array($this->config->get('scopes'))) {
             $this->scopes = $this->getConfig()->get('scopes');
-        } elseif ($this->config->has('scope') && is_string($this->getConfig()->get('scope'))) {
-            $this->scopes = array($this->getConfig()->get('scope'));
+        } elseif ($this->config->has(Contracts\RFC6749_ABNF_SCOPE) && is_string($this->getConfig()->get(Contracts\RFC6749_ABNF_SCOPE))) {
+            $this->scopes = array($this->getConfig()->get(Contracts\RFC6749_ABNF_SCOPE));
         }
 
-        // normalize 'client_id'
-        if (!$this->config->has('client_id')) {
-            $id = $this->config->get('app_id');
+        // normalize Contracts\RFC6749_ABNF_CLIENT_ID
+        if (!$this->config->has(Contracts\RFC6749_ABNF_CLIENT_ID)) {
+            $id = $this->config->get(Contracts\ABNF_APP_ID);
             if (null != $id) {
-                $this->config->set('client_id', $id);
+                $this->config->set(Contracts\RFC6749_ABNF_CLIENT_ID, $id);
             }
         }
 
-        // normalize 'client_secret'
-        if (!$this->config->has('client_secret')) {
-            $secret = $this->config->get('app_secret');
+        // normalize Contracts\RFC6749_ABNF_CLIENT_SECRET
+        if (!$this->config->has(Contracts\RFC6749_ABNF_CLIENT_SECRET)) {
+            $secret = $this->config->get(Contracts\ABNF_APP_SECRET);
             if (null != $secret) {
-                $this->config->set('client_secret', $secret);
+                $this->config->set(Contracts\RFC6749_ABNF_CLIENT_SECRET, $secret);
             }
         }
 
@@ -68,7 +68,7 @@ abstract class Base implements ProviderInterface
 
     abstract protected function getUserByToken(string $token): array;
 
-    abstract protected function mapUserToObject(array $user): UserInterface;
+    abstract protected function mapUserToObject(array $user): Contracts\UserInterface;
 
     public function redirect(?string $redirectUrl = null): string
     {
@@ -79,11 +79,7 @@ abstract class Base implements ProviderInterface
         return $this->getAuthUrl();
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Overtrue\Socialite\Exceptions\AuthorizeFailedException
-     */
-    public function userFromCode(string $code): UserInterface
+    public function userFromCode(string $code): Contracts\UserInterface
     {
         $tokenResponse = $this->tokenFromCode($code);
         $user = $this->userFromToken($tokenResponse[$this->accessTokenKey]);
@@ -93,16 +89,13 @@ abstract class Base implements ProviderInterface
             ->setTokenResponse($tokenResponse);
     }
 
-    public function userFromToken(string $token): UserInterface
+    public function userFromToken(string $token): Contracts\UserInterface
     {
         $user = $this->getUserByToken($token);
 
         return $this->mapUserToObject($user)->setProvider($this)->setRaw($user)->setAccessToken($token);
     }
 
-    /**
-     * @throws \Overtrue\Socialite\Exceptions\AuthorizeFailedException|\GuzzleHttp\Exception\GuzzleException
-     */
     public function tokenFromCode(string $code): array
     {
         $response = $this->getHttpClient()->post(
@@ -119,35 +112,35 @@ abstract class Base implements ProviderInterface
     }
 
     /**
-     * @throws \Overtrue\Socialite\Exceptions\MethodDoesNotSupportException
+     * @throws Exceptions\MethodDoesNotSupportException
      */
     public function refreshToken(string $refreshToken)
     {
-        throw new MethodDoesNotSupportException('refreshToken does not support.');
+        throw new Exceptions\MethodDoesNotSupportException('refreshToken does not support.');
     }
 
-    public function withRedirectUrl(string $redirectUrl): ProviderInterface
+    public function withRedirectUrl(string $redirectUrl): Contracts\ProviderInterface
     {
         $this->redirectUrl = $redirectUrl;
 
         return $this;
     }
 
-    public function withState(string $state): ProviderInterface
+    public function withState(string $state): Contracts\ProviderInterface
     {
         $this->state = $state;
 
         return $this;
     }
 
-    public function scopes(array $scopes): ProviderInterface
+    public function scopes(array $scopes): Contracts\ProviderInterface
     {
         $this->scopes = $scopes;
 
         return $this;
     }
 
-    public function with(array $parameters): ProviderInterface
+    public function with(array $parameters): Contracts\ProviderInterface
     {
         $this->parameters = $parameters;
 
@@ -159,7 +152,7 @@ abstract class Base implements ProviderInterface
         return $this->config;
     }
 
-    public function withScopeSeparator(string $scopeSeparator): ProviderInterface
+    public function withScopeSeparator(string $scopeSeparator): Contracts\ProviderInterface
     {
         $this->scopeSeparator = $scopeSeparator;
 
@@ -168,12 +161,12 @@ abstract class Base implements ProviderInterface
 
     public function getClientId(): ?string
     {
-        return $this->config->get('client_id');
+        return $this->config->get(Contracts\RFC6749_ABNF_CLIENT_ID);
     }
 
     public function getClientSecret(): ?string
     {
-        return $this->config->get('client_secret');
+        return $this->config->get(Contracts\RFC6749_ABNF_CLIENT_SECRET);
     }
 
     public function getHttpClient(): GuzzleClient
@@ -181,7 +174,7 @@ abstract class Base implements ProviderInterface
         return $this->httpClient ?? new GuzzleClient($this->guzzleOptions);
     }
 
-    public function setGuzzleOptions(array $config): ProviderInterface
+    public function setGuzzleOptions(array $config): Contracts\ProviderInterface
     {
         $this->guzzleOptions = $config;
 
@@ -195,28 +188,28 @@ abstract class Base implements ProviderInterface
 
     protected function formatScopes(array $scopes, string $scopeSeparator): string
     {
-        return implode($scopeSeparator, $scopes);
+        return \implode($scopeSeparator, $scopes);
     }
 
     #[ArrayShape([
-        'client_id' => "null|string",
-        'client_secret' => "null|string",
-        'code' => "string",
-        'redirect_uri' => "mixed"
+        Contracts\RFC6749_ABNF_CLIENT_ID => 'null|string',
+        Contracts\RFC6749_ABNF_CLIENT_SECRET => 'null|string',
+        Contracts\RFC6749_ABNF_CODE => 'string',
+        Contracts\RFC6749_ABNF_REDIRECT_URI => 'null|string'
     ])]
     protected function getTokenFields(string $code): array
     {
         return [
-            'client_id' => $this->getClientId(),
-            'client_secret' => $this->getClientSecret(),
-            'code' => $code,
-            'redirect_uri' => $this->redirectUrl,
+            Contracts\RFC6749_ABNF_CLIENT_ID => $this->getClientId(),
+            Contracts\RFC6749_ABNF_CLIENT_SECRET => $this->getClientSecret(),
+            Contracts\RFC6749_ABNF_CODE => $code,
+            Contracts\RFC6749_ABNF_REDIRECT_URI => $this->redirectUrl,
         ];
     }
 
     protected function buildAuthUrlFromBase(string $url): string
     {
-        $query = $this->getCodeFields() + ($this->state ? ['state' => $this->state] : []);
+        $query = $this->getCodeFields() + ($this->state ? [Contracts\RFC6749_ABNF_STATE => $this->state] : []);
 
         return $url . '?' . \http_build_query($query, '', '&', $this->encodingType);
     }
@@ -225,29 +218,29 @@ abstract class Base implements ProviderInterface
     {
         $fields = array_merge(
             [
-                'client_id' => $this->getClientId(),
-                'redirect_uri' => $this->redirectUrl,
-                'scope' => $this->formatScopes($this->scopes, $this->scopeSeparator),
-                'response_type' => 'code',
+                Contracts\RFC6749_ABNF_CLIENT_ID => $this->getClientId(),
+                Contracts\RFC6749_ABNF_REDIRECT_URI => $this->redirectUrl,
+                Contracts\RFC6749_ABNF_SCOPE => $this->formatScopes($this->scopes, $this->scopeSeparator),
+                Contracts\RFC6749_ABNF_RESPONSE_TYPE => Contracts\RFC6749_ABNF_CODE,
             ],
             $this->parameters
         );
 
         if ($this->state) {
-            $fields['state'] = $this->state;
+            $fields[Contracts\RFC6749_ABNF_STATE] = $this->state;
         }
 
         return $fields;
     }
 
     /**
-     * @throws \Overtrue\Socialite\Exceptions\AuthorizeFailedException
+     * @throws Exceptions\AuthorizeFailedException
      */
     protected function normalizeAccessTokenResponse($response): array
     {
-        if ($response instanceof Stream) {
-            $response->rewind();
-            $response = $response->getContents();
+        if ($response instanceof StreamInterface) {
+            $response->tell() && $response->rewind();
+            $response = (string) $response;
         }
 
         if (\is_string($response)) {
@@ -255,17 +248,22 @@ abstract class Base implements ProviderInterface
         }
 
         if (!\is_array($response)) {
-            throw new AuthorizeFailedException('Invalid token response', [$response]);
+            throw new Exceptions\AuthorizeFailedException('Invalid token response', [$response]);
         }
 
         if (empty($response[$this->accessTokenKey])) {
-            throw new AuthorizeFailedException('Authorize Failed: ' . json_encode($response, JSON_UNESCAPED_UNICODE), $response);
+            throw new Exceptions\AuthorizeFailedException('Authorize Failed: ' . json_encode($response, JSON_UNESCAPED_UNICODE), $response);
         }
 
         return $response + [
-                'access_token' => $response[$this->accessTokenKey],
-                'refresh_token' => $response[$this->refreshTokenKey] ?? null,
-                'expires_in' => \intval($response[$this->expiresInKey] ?? 0),
-            ];
+            Contracts\RFC6749_ABNF_ACCESS_TOKEN => $response[$this->accessTokenKey],
+            Contracts\RFC6749_ABNF_REFRESH_TOKEN => $response[$this->refreshTokenKey] ?? null,
+            Contracts\RFC6749_ABNF_EXPIRES_IN => \intval($response[$this->expiresInKey] ?? 0),
+        ];
+    }
+
+    protected function fromJsonBody(MessageInterface $response): array
+    {
+        return Utils::jsonDecode((string) $response->getBody(), true);
     }
 }

--- a/src/Providers/Douban.php
+++ b/src/Providers/Douban.php
@@ -4,7 +4,7 @@ namespace Overtrue\Socialite\Providers;
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\UserInterface;
+use Overtrue\Socialite\Contracts;
 use Overtrue\Socialite\User;
 
 /**
@@ -25,56 +25,50 @@ class Douban extends Base
     }
 
     /**
-     * @param  string  $token
-     * @param  array|null  $query
-     *
-     * @return array
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @param string $token
+     * @param ?array $query
      */
     protected function getUserByToken(string $token, ?array $query = []): array
     {
         $response = $this->getHttpClient()->get('https://api.douban.com/v2/user/~me', [
             'headers' => [
-                'Authorization' => 'Bearer '.$token,
+                'Authorization' => 'Bearer ' . $token,
             ],
         ]);
 
-        return json_decode($response->getBody()->getContents(), true) ?? [];
+        return $this->fromJsonBody($response);
     }
 
     #[Pure]
-    protected function mapUserToObject(array $user): UserInterface
+    protected function mapUserToObject(array $user): Contracts\UserInterface
     {
         return new User([
-            'id' => $user['id'] ?? null,
-            'nickname' => $user['name'] ?? null,
-            'name' => $user['name'] ?? null,
-            'avatar' => $user['avatar'] ?? null,
-            'email' => null,
+            Contracts\ABNF_ID => $user[Contracts\ABNF_ID] ?? null,
+            Contracts\ABNF_NICKNAME => $user[Contracts\ABNF_NAME] ?? null,
+            Contracts\ABNF_NAME => $user[Contracts\ABNF_NAME] ?? null,
+            Contracts\ABNF_AVATAR => $user[Contracts\ABNF_AVATAR] ?? null,
+            Contracts\ABNF_EMAIL => null,
         ]);
     }
 
     #[ArrayShape([
-        'client_id' => "\null|string",
-        'client_secret' => "\null|string",
-        'code' => "string",
-        'redirect_uri' => "mixed"
+        Contracts\RFC6749_ABNF_CLIENT_ID => 'null|string',
+        Contracts\RFC6749_ABNF_CLIENT_SECRET => 'null|string',
+        Contracts\RFC6749_ABNF_CODE => 'string',
+        Contracts\RFC6749_ABNF_REDIRECT_URI => 'null|string',
+        Contracts\RFC6749_ABNF_GRANT_TYPE => 'string',
     ])]
     protected function getTokenFields(string $code): array
     {
-        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
+        return parent::getTokenFields($code) + [Contracts\RFC6749_ABNF_GRANT_TYPE => Contracts\RFC6749_ABNF_AUTHORATION_CODE];
     }
 
-    /**
-     * @throws \Overtrue\Socialite\Exceptions\AuthorizeFailedException
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
     public function tokenFromCode(string $code): array
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'form_params' => $this->getTokenFields($code),
         ]);
 
-        return $this->normalizeAccessTokenResponse($response->getBody()->getContents());
+        return $this->normalizeAccessTokenResponse($response->getBody());
     }
 }

--- a/src/Providers/Facebook.php
+++ b/src/Providers/Facebook.php
@@ -3,7 +3,7 @@
 namespace Overtrue\Socialite\Providers;
 
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\UserInterface;
+use Overtrue\Socialite\Contracts;
 use Overtrue\Socialite\User;
 
 /**
@@ -12,6 +12,7 @@ use Overtrue\Socialite\User;
 class Facebook extends Base
 {
     public const NAME = 'facebook';
+
     protected string $graphUrl = 'https://graph.facebook.com';
     protected string $version = 'v3.3';
     protected array $fields = ['first_name', 'last_name', 'email', 'gender', 'verified'];
@@ -28,62 +29,52 @@ class Facebook extends Base
         return $this->graphUrl . '/oauth/access_token';
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Overtrue\Socialite\Exceptions\AuthorizeFailedException
-     */
     public function tokenFromCode(string $code): array
     {
-        $response = $this->getHttpClient()->get(
-            $this->getTokenUrl(),
-            [
-                'query' => $this->getTokenFields($code),
-            ]
-        );
+        $response = $this->getHttpClient()->get($this->getTokenUrl(), [
+            'query' => $this->getTokenFields($code),
+        ]);
 
         return $this->normalizeAccessTokenResponse($response->getBody());
     }
 
     /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     protected function getUserByToken(string $token, ?array $query = []): array
     {
-        $appSecretProof = hash_hmac('sha256', $token, $this->getConfig()->get('client_secret'));
-        $endpoint = $this->graphUrl . '/' . $this->version . '/me?access_token=' . $token . '&appsecret_proof=' . $appSecretProof . '&fields=' .
-            implode(',', $this->fields);
+        $appSecretProof = \hash_hmac('sha256', $token, $this->getConfig()->get(Contracts\RFC6749_ABNF_CLIENT_SECRET));
 
-        $response = $this->getHttpClient()->get(
-            $endpoint,
-            [
-                'headers' => [
-                    'Accept' => 'application/json',
-                ],
-            ]
-        );
+        $response = $this->getHttpClient()->get($this->graphUrl . '/' . $this->version . '/me', [
+            'query' => [
+                Contracts\RFC6749_ABNF_ACCESS_TOKEN => $token,
+                'appsecret_proof' => $appSecretProof,
+                'fields' => $this->formatScopes($this->fields, $this->scopeSeparator)
+            ],
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ]);
 
-        return \json_decode($response->getBody(), true) ?? [];
+        return $this->fromJsonBody($response);
     }
 
     #[Pure]
-    protected function mapUserToObject(array $user): UserInterface
+    protected function mapUserToObject(array $user): Contracts\UserInterface
     {
-        $userId = $user['id'] ?? null;
+        $userId = $user[Contracts\ABNF_ID] ?? null;
         $avatarUrl = $this->graphUrl . '/' . $this->version . '/' . $userId . '/picture';
 
         $firstName = $user['first_name'] ?? null;
         $lastName = $user['last_name'] ?? null;
 
-        return new User(
-            [
-                'id' => $user['id'] ?? null,
-                'nickname' => null,
-                'name' => $firstName . ' ' . $lastName,
-                'email' => $user['email'] ?? null,
-                'avatar' => $userId ? $avatarUrl . '?type=normal' : null,
-                'avatar_original' => $userId ? $avatarUrl . '?width=1920' : null,
-            ]
-        );
+        return new User([
+            Contracts\ABNF_ID => $user[Contracts\ABNF_ID] ?? null,
+            Contracts\ABNF_NICKNAME => null,
+            Contracts\ABNF_NAME => $firstName . ' ' . $lastName,
+            Contracts\ABNF_EMAIL => $user[Contracts\ABNF_EMAIL] ?? null,
+            Contracts\ABNF_AVATAR => $userId ? $avatarUrl . '?type=normal' : null,
+            'avatar_original' => $userId ? $avatarUrl . '?width=1920' : null,
+        ]);
     }
 
     protected function getCodeFields(): array
@@ -97,14 +88,14 @@ class Facebook extends Base
         return $fields;
     }
 
-    public function fields(array $fields): static
+    public function fields(array $fields): self
     {
         $this->fields = $fields;
 
         return $this;
     }
 
-    public function asPopup(): static
+    public function asPopup(): self
     {
         $this->popup = true;
 

--- a/src/Providers/Figma.php
+++ b/src/Providers/Figma.php
@@ -4,7 +4,7 @@ namespace Overtrue\Socialite\Providers;
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\UserInterface;
+use Overtrue\Socialite\Contracts;
 use Overtrue\Socialite\User;
 
 /**
@@ -13,6 +13,7 @@ use Overtrue\Socialite\User;
 class Figma extends Base
 {
     public const NAME = 'figma';
+
     protected string $scopeSeparator = '';
     protected array $scopes = ['file_read'];
 
@@ -40,46 +41,44 @@ class Figma extends Base
     }
 
     #[ArrayShape([
-        'client_id' => "\null|string",
-        'client_secret' => "\null|string",
-        'code' => "string",
-        'redirect_uri' => "mixed"
+        Contracts\RFC6749_ABNF_CLIENT_ID => "null|string",
+        Contracts\RFC6749_ABNF_CLIENT_SECRET => "null|string",
+        Contracts\RFC6749_ABNF_CODE => "string",
+        Contracts\RFC6749_ABNF_REDIRECT_URI => "null|string",
+        Contracts\RFC6749_ABNF_GRANT_TYPE => 'string'
     ])]
     protected function getTokenFields(string $code): array
     {
-        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
+        return parent::getTokenFields($code) + [Contracts\RFC6749_ABNF_GRANT_TYPE => Contracts\RFC6749_ABNF_AUTHORATION_CODE];
     }
 
     protected function getCodeFields(): array
     {
-        return parent::getCodeFields() + ['state' => \md5(\uniqid('state_', true))];
+        return parent::getCodeFields() + [Contracts\RFC6749_ABNF_STATE => \md5(\uniqid('state_', true))];
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
     protected function getUserByToken(string $token, ?array $query = []): array
     {
         $response = $this->getHttpClient()->get('https://api.figma.com/v1/me', [
             'headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => 'Bearer '.$token,
+                'Authorization' => 'Bearer ' . $token,
             ],
         ]);
 
-        return \json_decode($response->getBody(), true) ?? [];
+        return $this->fromJsonBody($response);
     }
 
     #[Pure]
-    protected function mapUserToObject(array $user): UserInterface
+    protected function mapUserToObject(array $user): Contracts\UserInterface
     {
         return new User([
-            'id' => $user['id'] ?? null,
-            'username' => $user['email'] ?? null,
-            'nickname' => $user['handle'] ?? null,
-            'name' => $user['handle'] ?? null,
-            'email' => $user['email'] ?? null,
-            'avatar' => $user['img_url'] ?? null,
+            Contracts\ABNF_ID => $user[Contracts\ABNF_ID] ?? null,
+            'username' => $user[Contracts\ABNF_EMAIL] ?? null,
+            Contracts\ABNF_NICKNAME => $user['handle'] ?? null,
+            Contracts\ABNF_NAME => $user['handle'] ?? null,
+            Contracts\ABNF_EMAIL => $user[Contracts\ABNF_EMAIL] ?? null,
+            Contracts\ABNF_AVATAR => $user['img_url'] ?? null,
         ]);
     }
 }

--- a/src/Providers/Gitee.php
+++ b/src/Providers/Gitee.php
@@ -4,17 +4,14 @@ namespace Overtrue\Socialite\Providers;
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\UserInterface;
+use Overtrue\Socialite\Contracts;
 use Overtrue\Socialite\User;
 
 class Gitee extends Base
 {
     public const NAME = 'gitee';
-    protected string $expiresInKey = 'expires_in';
-    protected string $accessTokenKey = 'access_token';
-    protected string $refreshTokenKey = 'refresh_token';
-    protected array $scopes = ['user_info'];
 
+    protected array $scopes = ['user_info'];
 
     protected function getAuthUrl(): string
     {
@@ -29,42 +26,42 @@ class Gitee extends Base
     protected function getUserByToken(string $token): array
     {
         $userUrl = 'https://gitee.com/api/v5/user';
-        $response = $this->getHttpClient()->get(
-            $userUrl,
-            [
-                'query' => ['access_token' => $token],
-            ]
-        );
-        return \json_decode($response->getBody()->getContents(), true) ?? [];
+        $response = $this->getHttpClient()->get($userUrl, [
+            'query' => [
+                Contracts\RFC6749_ABNF_ACCESS_TOKEN => $token
+            ],
+        ]);
+
+        return $this->fromJsonBody($response);
     }
 
     #[Pure]
-    protected function mapUserToObject(array $user): UserInterface
+    protected function mapUserToObject(array $user): Contracts\UserInterface
     {
         return new User([
-            'id' => $user['id'] ?? null,
-            'nickname' => $user['login'] ?? null,
-            'name' => $user['name'] ?? null,
-            'email' => $user['email'] ?? null,
-            'avatar' => $user['avatar_url'] ?? null,
+            Contracts\ABNF_ID => $user[Contracts\ABNF_ID] ?? null,
+            Contracts\ABNF_NICKNAME => $user['login'] ?? null,
+            Contracts\ABNF_NAME => $user[Contracts\ABNF_NAME] ?? null,
+            Contracts\ABNF_EMAIL => $user[Contracts\ABNF_EMAIL] ?? null,
+            Contracts\ABNF_AVATAR => $user['avatar_url'] ?? null,
         ]);
     }
 
     #[ArrayShape([
-        'client_id' => "null|string",
-        'client_secret' => "null|string",
-        'code' => "string",
-        'redirect_uri' => "mixed",
-        'grant_type' => "string"
+        Contracts\RFC6749_ABNF_CLIENT_ID => 'null|string',
+        Contracts\RFC6749_ABNF_CLIENT_SECRET => 'null|string',
+        Contracts\RFC6749_ABNF_CODE => 'string',
+        Contracts\RFC6749_ABNF_REDIRECT_URI => 'null|string',
+        Contracts\RFC6749_ABNF_GRANT_TYPE => 'string',
     ])]
     protected function getTokenFields(string $code): array
     {
         return [
-            'client_id' => $this->getClientId(),
-            'client_secret' => $this->getClientSecret(),
-            'code' => $code,
-            'redirect_uri' => $this->redirectUrl,
-            'grant_type' => 'authorization_code',
+            Contracts\RFC6749_ABNF_CLIENT_ID => $this->getClientId(),
+            Contracts\RFC6749_ABNF_CLIENT_SECRET => $this->getClientSecret(),
+            Contracts\RFC6749_ABNF_CODE => $code,
+            Contracts\RFC6749_ABNF_REDIRECT_URI => $this->redirectUrl,
+            Contracts\RFC6749_ABNF_GRANT_TYPE => Contracts\RFC6749_ABNF_AUTHORATION_CODE,
         ];
     }
 }

--- a/src/Providers/Google.php
+++ b/src/Providers/Google.php
@@ -4,7 +4,7 @@ namespace Overtrue\Socialite\Providers;
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\UserInterface;
+use Overtrue\Socialite\Contracts;
 use Overtrue\Socialite\User;
 
 /**
@@ -13,6 +13,7 @@ use Overtrue\Socialite\User;
 class Google extends Base
 {
     public const NAME = 'google';
+
     protected string $scopeSeparator = ' ';
     protected array $scopes = [
         'https://www.googleapis.com/auth/userinfo.email',
@@ -29,10 +30,6 @@ class Google extends Base
         return 'https://www.googleapis.com/oauth2/v4/token';
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Overtrue\Socialite\Exceptions\AuthorizeFailedException
-     */
     public function tokenFromCode(string $code): array
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
@@ -43,19 +40,17 @@ class Google extends Base
     }
 
     #[ArrayShape([
-        'client_id' => "\null|string",
-        'client_secret' => "\null|string",
-        'code' => "string",
-        'redirect_uri' => "mixed"
+        Contracts\RFC6749_ABNF_CLIENT_ID => 'null|string',
+        Contracts\RFC6749_ABNF_CLIENT_SECRET => 'null|string',
+        Contracts\RFC6749_ABNF_CODE => 'string',
+        Contracts\RFC6749_ABNF_REDIRECT_URI => 'null|string',
+        Contracts\RFC6749_ABNF_GRANT_TYPE => 'string',
     ])]
     protected function getTokenFields(string $code): array
     {
-        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
+        return parent::getTokenFields($code) + [Contracts\RFC6749_ABNF_GRANT_TYPE => Contracts\RFC6749_ABNF_AUTHORATION_CODE];
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
     protected function getUserByToken(string $token, ?array $query = []): array
     {
         $response = $this->getHttpClient()->get('https://www.googleapis.com/userinfo/v2/me', [
@@ -65,19 +60,19 @@ class Google extends Base
             ],
         ]);
 
-        return \json_decode($response->getBody(), true) ?? [];
+        return $this->fromJsonBody($response);
     }
 
     #[Pure]
-    protected function mapUserToObject(array $user): UserInterface
+    protected function mapUserToObject(array $user): Contracts\UserInterface
     {
         return new User([
-            'id' => $user['id'] ?? null,
-            'username' => $user['email'] ?? null,
-            'nickname' => $user['name'] ?? null,
-            'name' => $user['name'] ?? null,
-            'email' => $user['email'] ?? null,
-            'avatar' => $user['picture'] ?? null,
+            Contracts\ABNF_ID => $user[Contracts\ABNF_ID] ?? null,
+            'username' => $user[Contracts\ABNF_EMAIL] ?? null,
+            Contracts\ABNF_NICKNAME => $user[Contracts\ABNF_NAME] ?? null,
+            Contracts\ABNF_NAME => $user[Contracts\ABNF_NAME] ?? null,
+            Contracts\ABNF_EMAIL => $user[Contracts\ABNF_EMAIL] ?? null,
+            Contracts\ABNF_AVATAR => $user['picture'] ?? null,
         ]);
     }
 }

--- a/src/Providers/Line.php
+++ b/src/Providers/Line.php
@@ -4,7 +4,7 @@ namespace Overtrue\Socialite\Providers;
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\UserInterface;
+use Overtrue\Socialite\Contracts;
 use Overtrue\Socialite\User;
 
 /**
@@ -13,14 +13,16 @@ use Overtrue\Socialite\User;
 class Line extends Base
 {
     public const NAME = 'line';
+
     protected string $baseUrl = 'https://api.line.me/oauth2/';
     protected string $version = 'v2.1';
     protected array $scopes = ['profile'];
 
     protected function getAuthUrl(): string
     {
-        $this->state = $this->state ?: \md5(\uniqid('state', true));
-        return $this->buildAuthUrlFromBase('https://access.line.me/oauth2/'.$this->version.'/authorize');
+        $this->state = $this->state ?: \md5(\uniqid(Contracts\RFC6749_ABNF_STATE, true));
+
+        return $this->buildAuthUrlFromBase('https://access.line.me/oauth2/' . $this->version . '/authorize');
     }
 
     protected function getTokenUrl(): string
@@ -29,26 +31,17 @@ class Line extends Base
     }
 
     #[ArrayShape([
-        'client_id' => "null|string",
-        'client_secret' => "null|string",
-        'code' => "string",
-        'grant_type' => "string",
-        'redirect_uri' => "mixed"
+        Contracts\RFC6749_ABNF_CLIENT_ID => 'null|string',
+        Contracts\RFC6749_ABNF_CLIENT_SECRET => 'null|string',
+        Contracts\RFC6749_ABNF_CODE => 'string',
+        Contracts\RFC6749_ABNF_REDIRECT_URI => 'null|string',
+        Contracts\RFC6749_ABNF_GRANT_TYPE => 'string',
     ])]
     protected function getTokenFields(string $code): array
     {
-        return [
-            'client_id' => $this->getClientId(),
-            'client_secret' => $this->getClientSecret(),
-            'code' => $code,
-            'grant_type' => 'authorization_code',
-            'redirect_uri' => $this->redirectUrl,
-        ];
+        return parent::getTokenFields($code) + [Contracts\RFC6749_ABNF_GRANT_TYPE => Contracts\RFC6749_ABNF_AUTHORATION_CODE];
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
     protected function getUserByToken(string $token): array
     {
         $response = $this->getHttpClient()->get(
@@ -56,25 +49,23 @@ class Line extends Base
             [
                 'headers' => [
                     'Accept' => 'application/json',
-                    'Authorization' => 'Bearer '.$token,
+                    'Authorization' => 'Bearer ' . $token,
                 ],
             ]
         );
 
-        return \json_decode($response->getBody(), true) ?? [];
+        return $this->fromJsonBody($response);
     }
 
     #[Pure]
-    protected function mapUserToObject(array $user): UserInterface
+    protected function mapUserToObject(array $user): Contracts\UserInterface
     {
-        return new User(
-            [
-                'id' => $user['userId'] ?? null,
-                'name' => $user['displayName'] ?? null,
-                'nickname' => $user['displayName'] ?? null,
-                'avatar' => $user['pictureUrl'] ?? null,
-                'email' => null,
-            ]
-        );
+        return new User([
+            Contracts\ABNF_ID => $user['userId'] ?? null,
+            Contracts\ABNF_NAME => $user['displayName'] ?? null,
+            Contracts\ABNF_NICKNAME => $user['displayName'] ?? null,
+            Contracts\ABNF_AVATAR => $user['pictureUrl'] ?? null,
+            Contracts\ABNF_EMAIL => null,
+        ]);
     }
 }

--- a/src/Providers/Outlook.php
+++ b/src/Providers/Outlook.php
@@ -4,12 +4,13 @@ namespace Overtrue\Socialite\Providers;
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\UserInterface;
+use Overtrue\Socialite\Contracts;
 use Overtrue\Socialite\User;
 
 class Outlook extends Base
 {
     public const NAME = 'outlook';
+
     protected array $scopes = ['User.Read'];
     protected string $scopeSeparator = ' ';
 
@@ -23,45 +24,41 @@ class Outlook extends Base
         return 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
     protected function getUserByToken(string $token, ?array $query = []): array
     {
         $response = $this->getHttpClient()->get(
             'https://graph.microsoft.com/v1.0/me',
             ['headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => 'Bearer '.$token,
+                'Authorization' => 'Bearer ' . $token,
             ],
             ]
         );
 
-        return \json_decode($response->getBody()->getContents(), true) ?? [];
+        return $this->fromJsonBody($response);
     }
 
     #[Pure]
-    protected function mapUserToObject(array $user): UserInterface
+    protected function mapUserToObject(array $user): Contracts\UserInterface
     {
         return new User([
-            'id' => $user['id'] ?? null,
-            'nickname' => null,
-            'name' => $user['displayName'] ?? null,
-            'email' => $user['userPrincipalName'] ?? null,
-            'avatar' => null,
+            Contracts\ABNF_ID => $user[Contracts\ABNF_ID] ?? null,
+            Contracts\ABNF_NICKNAME => null,
+            Contracts\ABNF_NAME => $user['displayName'] ?? null,
+            Contracts\ABNF_EMAIL => $user['userPrincipalName'] ?? null,
+            Contracts\ABNF_AVATAR => null,
         ]);
     }
 
     #[ArrayShape([
-        'client_id' => "\null|string",
-        'client_secret' => "\null|string",
-        'code' => "string",
-        'redirect_uri' => "mixed"
+        Contracts\RFC6749_ABNF_CLIENT_ID => 'null|string',
+        Contracts\RFC6749_ABNF_CLIENT_SECRET => 'null|string',
+        Contracts\RFC6749_ABNF_CODE => 'string',
+        Contracts\RFC6749_ABNF_REDIRECT_URI => 'null|string',
+        Contracts\RFC6749_ABNF_GRANT_TYPE => 'string',
     ])]
     protected function getTokenFields(string $code): array
     {
-        return parent::getTokenFields($code) + [
-            'grant_type' => 'authorization_code',
-        ];
+        return parent::getTokenFields($code) + [Contracts\RFC6749_ABNF_GRANT_TYPE => Contracts\RFC6749_ABNF_AUTHORATION_CODE];
     }
 }

--- a/src/Providers/Taobao.php
+++ b/src/Providers/Taobao.php
@@ -4,7 +4,7 @@ namespace Overtrue\Socialite\Providers;
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\UserInterface;
+use Overtrue\Socialite\Contracts;
 use Overtrue\Socialite\User;
 
 /**
@@ -13,12 +13,13 @@ use Overtrue\Socialite\User;
 class Taobao extends Base
 {
     public const NAME = 'taobao';
+
     protected string $baseUrl = 'https://oauth.taobao.com';
     protected string $gatewayUrl = 'https://eco.taobao.com/router/rest';
     protected string $view = 'web';
     protected array $scopes = ['user_info'];
 
-    public function withView(string $view): static
+    public function withView(string $view): self
     {
         $this->view = $view;
 
@@ -27,91 +28,89 @@ class Taobao extends Base
 
     protected function getAuthUrl(): string
     {
-        return $this->buildAuthUrlFromBase($this->baseUrl.'/authorize');
+        return $this->buildAuthUrlFromBase($this->baseUrl . '/authorize');
     }
 
     #[ArrayShape([
-        'client_id' => "null|string",
-        'redirect_uri' => "mixed",
-        'view' => "string",
-        'response_type' => "string"
+        Contracts\RFC6749_ABNF_CLIENT_ID => 'null|string',
+        Contracts\RFC6749_ABNF_REDIRECT_URI => 'null|string',
+        'view' => 'string',
+        Contracts\RFC6749_ABNF_RESPONSE_TYPE => 'string'
     ])]
     public function getCodeFields(): array
     {
         return [
-            'client_id' => $this->getClientId(),
-            'redirect_uri' => $this->redirectUrl,
+            Contracts\RFC6749_ABNF_CLIENT_ID => $this->getClientId(),
+            Contracts\RFC6749_ABNF_REDIRECT_URI => $this->redirectUrl,
             'view' => $this->view,
-            'response_type' => 'code',
+            Contracts\RFC6749_ABNF_RESPONSE_TYPE => Contracts\RFC6749_ABNF_CODE,
         ];
     }
 
     protected function getTokenUrl(): string
     {
-        return $this->baseUrl.'/token';
+        return $this->baseUrl . '/token';
     }
 
     #[ArrayShape([
-        'client_id' => "\null|string",
-        'client_secret' => "\null|string",
-        'code' => "string",
-        'redirect_uri' => "mixed"
+        Contracts\RFC6749_ABNF_CLIENT_ID => 'null|string',
+        Contracts\RFC6749_ABNF_CLIENT_SECRET => 'null|string',
+        Contracts\RFC6749_ABNF_CODE => 'string',
+        Contracts\RFC6749_ABNF_REDIRECT_URI => 'null|string',
+        Contracts\RFC6749_ABNF_GRANT_TYPE => 'string',
+        'view' => 'string',
     ])]
-    protected function getTokenFields($code): array
+    protected function getTokenFields(string $code): array
     {
-        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code', 'view' => $this->view];
+        return parent::getTokenFields($code) + [
+            Contracts\RFC6749_ABNF_GRANT_TYPE =>Contracts\RFC6749_ABNF_AUTHORATION_CODE,
+            'view' => $this->view
+        ];
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Overtrue\Socialite\Exceptions\AuthorizeFailedException
-     */
     public function tokenFromCode(string $code): array
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'query' => $this->getTokenFields($code),
         ]);
 
-        return $this->normalizeAccessTokenResponse($response->getBody()->getContents());
+        return $this->normalizeAccessTokenResponse($response->getBody());
     }
 
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
     protected function getUserByToken(string $token, ?array $query = []): array
     {
         $response = $this->getHttpClient()->post($this->getUserInfoUrl($this->gatewayUrl, $token));
 
-        return \json_decode($response->getBody()->getContents(), true) ?? [];
+        return $this->fromJsonBody($response);
     }
 
     #[Pure]
-    protected function mapUserToObject(array $user): UserInterface
+    protected function mapUserToObject(array $user): Contracts\UserInterface
     {
         return new User([
-            'id' => $user['open_id'] ?? null,
-            'nickname' => $user['nick'] ?? null,
-            'name' => $user['nick'] ?? null,
-            'avatar' => $user['avatar'] ?? null,
-            'email' => $user['email'] ?? null,
+            Contracts\ABNF_ID => $user[Contracts\ABNF_OPEN_ID] ?? null,
+            Contracts\ABNF_NICKNAME => $user['nick'] ?? null,
+            Contracts\ABNF_NAME => $user['nick'] ?? null,
+            Contracts\ABNF_AVATAR => $user[Contracts\ABNF_AVATAR] ?? null,
+            Contracts\ABNF_EMAIL => $user[Contracts\ABNF_EMAIL] ?? null,
         ]);
     }
 
     protected function generateSign(array $params): string
     {
-        ksort($params);
+        \ksort($params);
 
-        $stringToBeSigned = $this->getConfig()->get('client_secret');
+        $stringToBeSigned = $this->getConfig()->get(Contracts\RFC6749_ABNF_CLIENT_SECRET);
 
         foreach ($params as $k => $v) {
-            if (!is_array($v) && !str_starts_with($v, '@')) {
+            if (!\is_array($v) && !\str_starts_with($v, '@')) {
                 $stringToBeSigned .= "$k$v";
             }
         }
 
-        $stringToBeSigned .= $this->getConfig()->get('client_secret');
+        $stringToBeSigned .= $this->getConfig()->get(Contracts\RFC6749_ABNF_CLIENT_SECRET);
 
-        return strtoupper(md5($stringToBeSigned));
+        return \strtoupper(\md5($stringToBeSigned));
     }
 
     protected function getPublicFields(string $token, array $apiFields = []): array
@@ -120,12 +119,12 @@ class Taobao extends Base
             'app_key' => $this->getClientId(),
             'sign_method' => 'md5',
             'session' => $token,
-            'timestamp' => \date('Y-m-d H:i:s'),
+            'timestamp' => (new \DateTime('now', new \DateTimeZone('Asia/Shanghai')))->format('Y-m-d H:i:s'),
             'v' => '2.0',
             'format' => 'json',
         ];
 
-        $fields = array_merge($apiFields, $fields);
+        $fields = \array_merge($apiFields, $fields);
         $fields['sign'] = $this->generateSign($fields);
 
         return $fields;
@@ -135,8 +134,8 @@ class Taobao extends Base
     {
         $apiFields = ['method' => 'taobao.miniapp.userInfo.get'];
 
-        $query = http_build_query($this->getPublicFields($token, $apiFields), '', '&', $this->encodingType);
+        $query = \http_build_query($this->getPublicFields($token, $apiFields), '', '&', $this->encodingType);
 
-        return $url.'?'.$query;
+        return $url . '?' . $query;
     }
 }

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -3,39 +3,36 @@
 namespace Overtrue\Socialite;
 
 use Closure;
-use InvalidArgumentException;
 use JetBrains\PhpStorm\Pure;
-use Overtrue\Socialite\Contracts\FactoryInterface;
-use Overtrue\Socialite\Contracts\ProviderInterface;
 
-class SocialiteManager implements FactoryInterface
+class SocialiteManager implements Contracts\FactoryInterface
 {
     protected Config $config;
     protected array $resolved = [];
-    protected array $customCreators = [];
-    protected array $providers = [
-        Providers\QQ::NAME => Providers\QQ::class,
-        Providers\Tapd::NAME => Providers\Tapd::class,
-        Providers\Weibo::NAME => Providers\Weibo::class,
+    protected static array $customCreators = [];
+    protected const PROVIDERS = [
         Providers\Alipay::NAME => Providers\Alipay::class,
-        Providers\QCloud::NAME => Providers\QCloud::class,
-        Providers\GitHub::NAME => Providers\GitHub::class,
-        Providers\Google::NAME => Providers\Google::class,
-        Providers\Figma::NAME => Providers\Figma::class,
-        Providers\WeChat::NAME => Providers\WeChat::class,
-        Providers\Douban::NAME => Providers\Douban::class,
-        Providers\WeWork::NAME => Providers\WeWork::class,
-        Providers\DouYin::NAME => Providers\DouYin::class,
-        Providers\Taobao::NAME => Providers\Taobao::class,
-        Providers\FeiShu::NAME => Providers\FeiShu::class,
-        Providers\Outlook::NAME => Providers\Outlook::class,
         Providers\Azure::NAME => Providers\Azure::class,
-        Providers\Linkedin::NAME => Providers\Linkedin::class,
-        Providers\Facebook::NAME => Providers\Facebook::class,
         Providers\DingTalk::NAME => Providers\DingTalk::class,
-        Providers\OpenWeWork::NAME => Providers\OpenWeWork::class,
-        Providers\Line::NAME => Providers\Line::class,
+        Providers\DouYin::NAME => Providers\DouYin::class,
+        Providers\Douban::NAME => Providers\Douban::class,
+        Providers\Facebook::NAME => Providers\Facebook::class,
+        Providers\FeiShu::NAME => Providers\FeiShu::class,
+        Providers\Figma::NAME => Providers\Figma::class,
+        Providers\GitHub::NAME => Providers\GitHub::class,
         Providers\Gitee::NAME => Providers\Gitee::class,
+        Providers\Google::NAME => Providers\Google::class,
+        Providers\Line::NAME => Providers\Line::class,
+        Providers\Linkedin::NAME => Providers\Linkedin::class,
+        Providers\OpenWeWork::NAME => Providers\OpenWeWork::class,
+        Providers\Outlook::NAME => Providers\Outlook::class,
+        Providers\QCloud::NAME => Providers\QCloud::class,
+        Providers\QQ::NAME => Providers\QQ::class,
+        Providers\Taobao::NAME => Providers\Taobao::class,
+        Providers\Tapd::NAME => Providers\Tapd::class,
+        Providers\WeChat::NAME => Providers\WeChat::class,
+        Providers\WeWork::NAME => Providers\WeWork::class,
+        Providers\Weibo::NAME => Providers\Weibo::class,
     ];
 
     #[Pure]
@@ -51,9 +48,9 @@ class SocialiteManager implements FactoryInterface
         return $this;
     }
 
-    public function create(string $name): ProviderInterface
+    public function create(string $name): Contracts\ProviderInterface
     {
-        $name = strtolower($name);
+        $name = \strtolower($name);
 
         if (!isset($this->resolved[$name])) {
             $this->resolved[$name] = $this->createProvider($name);
@@ -64,7 +61,7 @@ class SocialiteManager implements FactoryInterface
 
     public function extend(string $name, Closure $callback): self
     {
-        $this->customCreators[strtolower($name)] = $callback;
+        self::$customCreators[\strtolower($name)] = $callback;
 
         return $this;
     }
@@ -74,37 +71,37 @@ class SocialiteManager implements FactoryInterface
         return $this->resolved;
     }
 
-    public function buildProvider(string $provider, array $config): ProviderInterface
+    public function buildProvider(string $provider, array $config): Contracts\ProviderInterface
     {
         return new $provider($config);
     }
 
     /**
-     * @throws \InvalidArgumentException
+     * @throws Exceptions\InvalidArgumentException
      */
-    protected function createProvider(string $name): ProviderInterface
+    protected function createProvider(string $name): Contracts\ProviderInterface
     {
         $config = $this->config->get($name, []);
         $provider = $config['provider'] ?? $name;
 
-        if (isset($this->customCreators[$provider])) {
+        if (isset(self::$customCreators[$provider])) {
             return $this->callCustomCreator($provider, $config);
         }
 
         if (!$this->isValidProvider($provider)) {
-            throw new InvalidArgumentException("Provider [$provider] not supported.");
+            throw new Exceptions\InvalidArgumentException("Provider [{$name}] not supported.");
         }
 
-        return $this->buildProvider($this->providers[$provider] ?? $provider, $config);
+        return $this->buildProvider(self::PROVIDERS[$provider] ?? $provider, $config);
     }
 
-    protected function callCustomCreator(string $name, array $config): ProviderInterface
+    protected function callCustomCreator(string $name, array $config): Contracts\ProviderInterface
     {
-        return $this->customCreators[$name]($config);
+        return self::$customCreators[$name]($config);
     }
 
     protected function isValidProvider(string $provider): bool
     {
-        return isset($this->providers[$provider]) || is_subclass_of($provider, ProviderInterface::class);
+        return isset(self::PROVIDERS[$provider]) || \is_subclass_of($provider, Contracts\ProviderInterface::class);
     }
 }

--- a/src/Traits/HasAttributes.php
+++ b/src/Traits/HasAttributes.php
@@ -18,23 +18,23 @@ trait HasAttributes
         return $this->attributes[$name] ?? $default;
     }
 
-    public function setAttribute(string $name, mixed $value): static
+    public function setAttribute(string $name, mixed $value): self
     {
         $this->attributes[$name] = $value;
 
         return $this;
     }
 
-    public function merge(array $attributes): static
+    public function merge(array $attributes): self
     {
-        $this->attributes = array_merge($this->attributes, $attributes);
+        $this->attributes = \array_merge($this->attributes, $attributes);
 
         return $this;
     }
 
     public function offsetExists(mixed $offset): bool
     {
-        return array_key_exists($offset, $this->attributes);
+        return \array_key_exists($offset, $this->attributes);
     }
 
     public function offsetGet(mixed $offset): mixed

--- a/src/User.php
+++ b/src/User.php
@@ -4,78 +4,75 @@ namespace Overtrue\Socialite;
 
 use ArrayAccess;
 use JsonSerializable;
-use Overtrue\Socialite\Contracts\ProviderInterface;
-use Overtrue\Socialite\Contracts\UserInterface;
-use Overtrue\Socialite\Traits\HasAttributes;
 
-class User implements ArrayAccess, UserInterface, JsonSerializable
+class User implements ArrayAccess, Contracts\UserInterface, JsonSerializable
 {
-    use HasAttributes;
+    use Traits\HasAttributes;
 
-    public function __construct(array $attributes, protected ?ProviderInterface $provider = null)
+    public function __construct(array $attributes, protected ?Contracts\ProviderInterface $provider = null)
     {
         $this->attributes = $attributes;
     }
 
     public function getId(): mixed
     {
-        return $this->getAttribute('id') ?? $this->getEmail();
+        return $this->getAttribute(Contracts\ABNF_ID) ?? $this->getEmail();
     }
 
     public function getNickname(): ?string
     {
-        return $this->getAttribute('nickname') ?? $this->getName();
+        return $this->getAttribute(Contracts\ABNF_NICKNAME) ?? $this->getName();
     }
 
     public function getName(): ?string
     {
-        return $this->getAttribute('name');
+        return $this->getAttribute(Contracts\ABNF_NAME);
     }
 
     public function getEmail(): ?string
     {
-        return $this->getAttribute('email');
+        return $this->getAttribute(Contracts\ABNF_EMAIL);
     }
 
     public function getAvatar(): ?string
     {
-        return $this->getAttribute('avatar');
+        return $this->getAttribute(Contracts\ABNF_AVATAR);
     }
 
-    public function setAccessToken(string $token): self
+    public function setAccessToken(string $value): self
     {
-        $this->setAttribute('access_token', $token);
+        $this->setAttribute(Contracts\RFC6749_ABNF_ACCESS_TOKEN, $value);
 
         return $this;
     }
 
     public function getAccessToken(): ?string
     {
-        return $this->getAttribute('access_token');
+        return $this->getAttribute(Contracts\RFC6749_ABNF_ACCESS_TOKEN);
     }
 
-    public function setRefreshToken(?string $refreshToken): self
+    public function setRefreshToken(?string $value): self
     {
-        $this->setAttribute('refresh_token', $refreshToken);
+        $this->setAttribute(Contracts\RFC6749_ABNF_REFRESH_TOKEN, $value);
 
         return $this;
     }
 
     public function getRefreshToken(): ?string
     {
-        return $this->getAttribute('refresh_token');
+        return $this->getAttribute(Contracts\RFC6749_ABNF_REFRESH_TOKEN);
     }
 
-    public function setExpiresIn(int $expiresIn): self
+    public function setExpiresIn(int $value): self
     {
-        $this->setAttribute('expires_in', $expiresIn);
+        $this->setAttribute(Contracts\RFC6749_ABNF_EXPIRES_IN, $value);
 
         return $this;
     }
 
     public function getExpiresIn(): ?int
     {
-        return $this->getAttribute('expires_in');
+        return $this->getAttribute(Contracts\RFC6749_ABNF_EXPIRES_IN);
     }
 
     public function setRaw(array $user): self
@@ -90,7 +87,7 @@ class User implements ArrayAccess, UserInterface, JsonSerializable
         return $this->getAttribute('raw');
     }
 
-    public function setTokenResponse(array $response): static
+    public function setTokenResponse(array $response): self
     {
         $this->setAttribute('token_response', $response);
 
@@ -117,12 +114,12 @@ class User implements ArrayAccess, UserInterface, JsonSerializable
         $this->attributes = $serialized ?: [];
     }
 
-    public function getProvider(): \Overtrue\Socialite\Contracts\ProviderInterface
+    public function getProvider(): Contracts\ProviderInterface
     {
         return $this->provider;
     }
 
-    public function setProvider(\Overtrue\Socialite\Contracts\ProviderInterface $provider): static
+    public function setProvider(Contracts\ProviderInterface $provider): self
     {
         $this->provider = $provider;
 

--- a/tests/Providers/FeiShuTest.php
+++ b/tests/Providers/FeiShuTest.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Client;
-use Overtrue\Socialite\Exceptions\Feishu\InvalidTicketException;
+use Overtrue\Socialite\Exceptions\FeiShu\InvalidTicketException;
 use Overtrue\Socialite\Exceptions\InvalidTokenException;
 use Overtrue\Socialite\Providers\FeiShu;
 use PHPUnit\Framework\TestCase;
@@ -110,7 +110,7 @@ class FeiShuTest extends TestCase
 
         $mock = new MockHandler([
             new Response(403, []),
-            new Response(200, [], json_encode([
+            new Response(200, [], \json_encode([
                 'app_access_token' => 'app_access_token'
             ]))
         ]);
@@ -146,7 +146,7 @@ class FeiShuTest extends TestCase
         $ff = new \ReflectionMethod(FeiShu::class, 'configAppAccessToken');
 
         $mock = new MockHandler([
-            new Response(200, []),
+            new Response(200, [], '{}'),
         ]);
 
         $handler = HandlerStack::create($mock);
@@ -172,7 +172,7 @@ class FeiShuTest extends TestCase
         $ff = new \ReflectionMethod(FeiShu::class, 'configAppAccessToken');
 
         $mock = new MockHandler([
-            new Response(200, [], json_encode([
+            new Response(200, [], \json_encode([
                 'app_access_token' => 'app_access_token'
             ]))
         ]);
@@ -202,7 +202,7 @@ class FeiShuTest extends TestCase
         $ff = new \ReflectionMethod(FeiShu::class, 'configAppAccessToken');
 
         $mock = new MockHandler([
-            new Response(200, []),
+            new Response(200, [], '{}'),
         ]);
 
         $handler = HandlerStack::create($mock);
@@ -229,7 +229,7 @@ class FeiShuTest extends TestCase
         $ff = new \ReflectionMethod(FeiShu::class, 'configAppAccessToken');
 
         $mock = new MockHandler([
-            new Response(200, [], json_encode([
+            new Response(200, [], \json_encode([
                 'app_access_token' => 'app_access_token'
             ]))
         ]);

--- a/tests/Providers/WechatTest.php
+++ b/tests/Providers/WechatTest.php
@@ -3,6 +3,9 @@
 use PHPUnit\Framework\TestCase;
 use Overtrue\Socialite\Providers\WeChat;
 
+// here we need loaded the symbols first.
+\class_exists(\Overtrue\Socialite\Contracts\FactoryInterface::class);
+
 class WechatTest extends TestCase
 {
     public function testWeChatProviderHasCorrectlyRedirectResponse()


### PR DESCRIPTION
1. 遵循`RFC6749`规范，引入命名空间常量`RFC6749_ABNF_*`定义，从代码层面即可直观感受各`Providers`对规范的遵循度;
2. 在抽象`User`类，引入命名空间常量`ABNF_*`定义，直观感受对各厂商的授权信息抽象;
3. 在工厂抽象类中，引入命名空间常量`ABNF_*`定义，直观感受本LIB对`RFC6749`及厂商实现的抽象；
4. 调优`Psr\Http\Message\ResponseInterface::getBody()`获取返回值可能引发的流偏移而拿不到返回文本的潜在问题;
5. 使用相对路径的命名空间导入功能，对代码做了一点点修型;
6. 扔掉了下游包抛送的异常注释，代码注释仅专注于本LIB抛送的异常定义;
7. 支付宝&钉钉的`scope`拼接修型;
8. BC: 大小写`Exceptions\Feishu`调整为`Exceptions\FeiShu`;
9. BC: 部分抛送的异常调整为恰当类型;