### PR TITLE
Removing the email from the scope for Facebook

### DIFF
--- a/src/Providers/Facebook.php
+++ b/src/Providers/Facebook.php
@@ -19,7 +19,7 @@ class Facebook extends Base
 
     protected array $fields = ['first_name', 'last_name', 'email', 'gender', 'verified'];
 
-    protected array $scopes = ['email'];
+    protected array $scopes = [];
 
     protected bool $popup = false;
 


### PR DESCRIPTION
The email permission is not provided by default in Facebook apps.
Therefore, we should not assign "email" in the scope.
If we assing "email" field in the scope, the email will be added to the authorize url and it will fail if devlopers don't request email permission for their Facebook apps.

I provided the return url when I try the Facebook login.

https://www.facebook.com/v3.3/dialog/oauth?client_id=xxxxxx&redirect_uri=https%3A%2F%2Fxxx.xxx%2Fcallback.php&scope=email&response_type=code

You can see that there is a extra parameter "scope=email" is added in the url and it will cause the failure for Facebook login.