### PR TITLE
add picture field for user's avatar

### DIFF
--- a/src/Providers/Facebook.php
+++ b/src/Providers/Facebook.php
@@ -17,7 +17,7 @@ class Facebook extends Base
 
     protected string $version = 'v3.3';
 
-    protected array $fields = ['first_name', 'last_name', 'email', 'gender', 'verified'];
+    protected array $fields = ['first_name', 'last_name', 'email', 'gender', 'verified','picture'];
 
     protected array $scopes = [];
 


### PR DESCRIPTION
To get the user's avatar correctly, we need to add "picture" field in the $fields array.

Ps.
According to the previous code, I used below code to get the avatar of users correctly.
But I found that the code is changed after I did the testing and I didn't test the new code, I shared the code I used which can fetch users's avatar correctly.


```
protected function mapUserToObject(array $user): User
    {
        $userId = $user['id'] ?? null;
        if(isset($user['picture'])) {
            if(empty($user['picture']['data']['is_silhouette'])) {
                $avatarUrl = $user['picture']['data']['url'];
            } else {
                $avatarUrl = $this->graphUrl . '/' . $this->version . '/' . $userId . '/picture?type=normal';
            }
        } else {
            $avatarUrl = null;
        }

        $firstName = $user['first_name'] ?? null;
        $lastName = $user['last_name'] ?? null;

        return new User(
            [
                'id' => $user['id'] ?? null,
                'nickname' => null,
                'name' => $firstName . ' ' . $lastName,
                'email' => $user['email'] ?? null,
                'avatar' => $avatarUrl,
                'avatar_original' => $userId ? $avatarUrl . '?width=1920' : null,
            ]
        );
    }

```

I tried to dump the $user array and it's content is similar below:

```
Array
(
    [first_name] => xxx
    [last_name] => xxx
    [picture] => Array
        (
            [data] => Array
                (
                    [height] => 50
                    [is_silhouette] =>
                    [url] => https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=xxx&height=50&width=50&ext=xxx&hash=xxx
                    [width] => 50
                )
        )
    [id] => xxx
)
```
