### PR TITLE
从 composer.json 中移除 symfony/http-foundation 依赖

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.0",
-    "symfony/http-foundation": "^6.0",
     "symfony/psr-http-message-bridge": "^2.1|^6.0"
   },
   "require-dev": {


### PR DESCRIPTION
#272 在本项目没有发现 `symfony/http-foundation` 的直接使用