### PR TITLE
composer: 移除 symfony/http-foundation 的直接依赖

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
   },
   "require": {
     "php": ">=7.4",
-    "symfony/http-foundation": "^5.0",
     "guzzlehttp/guzzle": "~6.0|~7.0",
     "ext-json": "*",
     "symfony/psr-http-message-bridge": "^2.0",


### PR DESCRIPTION
项目没有直接依赖 symfony/http-foundation
项目依赖 symfony/psr-http-message-bridge 依赖了 symfony/http-foundation

移除此直接依赖能提供更大的版本兼容行