### PR TITLE
fix: resolve "Undefined array key 'openid'" error in wechat oauth snsapi_base scope

### DIFF
--- a/src/Providers/WeChat.php
+++ b/src/Providers/WeChat.php
@@ -113,11 +113,10 @@ class WeChat extends Base
 
     public function userFromCode(string $code): Contracts\UserInterface
     {
-        if (\in_array('snsapi_base', $this->scopes)) {
-            return $this->getSnsapiBaseUserFromCode($code);
-        }
-
         $token = $this->tokenFromCode($code);
+        if (\in_array('snsapi_base', $this->scopes)) {
+            return $this->getSnsapiBaseUserFromCode($token);
+        }
 
         $this->withOpenid($token['openid']);
 
@@ -128,9 +127,8 @@ class WeChat extends Base
             ->setTokenResponse($token);
     }
 
-    protected function getSnsapiBaseUserFromCode(string $code): Contracts\UserInterface
+    protected function getSnsapiBaseUserFromCode(array $token): Contracts\UserInterface
     {
-        $token = $this->fromJsonBody($this->getTokenFromCode($code));
         $user = [
             'openid' => $token['openid'],
         ];


### PR DESCRIPTION
fix: resolve "Undefined array key 'openid'" error in wechat oauth snsapi_base scope

微信静默授权登录的时候，如果非正常响应的时候，会报错Undefined array key \"openid\"，原因是getSnsapiBaseUserFromCode函数中的$token实际上是{"errcode":40029,"errmsg":"invalid code, rid: xxxxx"}，本次修改是将两种授权都走tokenFromCode函数，内部会调用normalizeAccessTokenResponse进行错误拦截