### PR TITLE
[codex] Support redirect_uri config in Google userFromCode flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $config = [
     'github' => [
         'client_id'     => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect'      => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 ];
 
@@ -68,7 +68,7 @@ $config = [
     'github' => [
         'client_id' => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect' => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 ];
 
@@ -88,7 +88,8 @@ $user->getEmail();     // "anzhengchao@gmail.com"
 
 ## 配置
 
-为每个平台设置相同的键值对后就能开箱即用：`client_id`, `client_secret`, `redirect`.
+为每个平台设置相同的键值对后就能开箱即用：`client_id`, `client_secret`, `redirect_uri`。
+同时兼容旧键名：`redirect`、`redirect_url`。
 
 示例：
 
@@ -97,12 +98,12 @@ $config = [
   'weibo' => [
     'client_id'     => 'your-app-id',
     'client_secret' => 'your-app-secret',
-    'redirect'      => 'http://localhost/socialite/callback.php',
+    'redirect_uri' => 'http://localhost/socialite/callback.php',
   ],
   'facebook' => [
     'client_id'     => 'your-app-id',
     'client_secret' => 'your-app-secret',
-    'redirect'      => 'http://localhost/socialite/callback.php',
+    'redirect_uri' => 'http://localhost/socialite/callback.php',
   ],
 ];
 ```
@@ -118,7 +119,7 @@ $config = [
         'provider'    => 'github',  // <-- provider name
         'client_id'   => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect'    => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 
     // 另外一个名字叫做 bar 的 github 应用
@@ -126,7 +127,7 @@ $config = [
         'provider'    => 'github',  // <-- provider name
         'client_id'   => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect'    => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 
     //...
@@ -152,7 +153,7 @@ $config = [
         'provider' => 'myprovider',  // <-- 一个工具还未支持的服务提供程序
         'client_id' => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect' => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 ];
 
@@ -186,7 +187,7 @@ $config = [
         'provider'    => MyCustomProvider::class,  // <-- 类名
         'client_id'   => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect'    => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 ];
 
@@ -215,8 +216,8 @@ $config = [
     'rsa_private_key' => 'your-rsa-private-key',
 
     // 确保这里的值与你在服务后台绑定的地址值一致
-    // 这个键名还能像官方文档那样叫做 'redirect_url'
-    'redirect' => 'http://localhost/socialite/callback.php',
+    // 推荐使用 'redirect_uri'，同时兼容 'redirect' 与 'redirect_url'
+    'redirect_uri' => 'http://localhost/socialite/callback.php',
 
     // 沙箱模式接入地址见 https://opendocs.alipay.com/open/220/105337#%E5%85%B3%E4%BA%8E%E6%B2%99%E7%AE%B1
     'sandbox' => false,
@@ -253,8 +254,8 @@ $config = [
       // or 'app_secret'
       'client_secret' => 'your app secret',
 
-      // or 'redirect_url'
-      'redirect' => 'redirect URL'
+      // 兼容旧键名：'redirect' 或 'redirect_url'
+      'redirect_uri' => 'redirect URL'
   ]
 ];
 
@@ -281,7 +282,7 @@ $config = [
 
       'client_secret' => 'your app secret',
 
-      'redirect' => 'redirect URL'
+      'redirect_uri' => 'redirect URL'
   ]
 ];
 
@@ -301,7 +302,7 @@ $config = [
   'toutiao' => [
     'client_id' => 'your app id',
     'client_secret' => 'your app secret',
-    'redirect' => 'redirect URL'
+    'redirect_uri' => 'redirect URL'
   ]
 ];
 
@@ -320,7 +321,7 @@ $config = [
   'xigua' => [
     'client_id' => 'your app id',
     'client_secret' => 'your app secret',
-    'redirect' => 'redirect URL'
+    'redirect_uri' => 'redirect URL'
   ]
 ];
 
@@ -361,8 +362,8 @@ $config = [
         // or 'app_secret'
         'client_secret' => 'your app secret',
 
-        // or 'redirect_url'
-        'redirect' => 'redirect URL',
+        // 兼容旧键名：'redirect' 或 'redirect_url'
+        'redirect_uri' => 'redirect URL',
 
         // 如果你想使用使用内部应用的方式获取 app_access_token
         // 对这个键设置了 'internal' 值那么你已经开启了内部应用模式
@@ -391,8 +392,8 @@ $config = [
         // or 'app_secret'
         'client_secret' => 'your app secret',
 
-        // or 'redirect_url'
-        'redirect' => 'redirect URL',
+        // 兼容旧键名：'redirect' 或 'redirect_url'
+        'redirect_uri' => 'redirect URL',
 
         // 如果你想使用使用内部应用的方式获取 app_access_token
         // 对这个键设置了 'internal' 值那么你已经开启了内部应用模式
@@ -431,7 +432,7 @@ $authUrl = $socialite->create('taobao')->withView('wap')->redirect();
         [
             'client_id'   => 'client_id',
             'client_secret' => 'client_secret',
-            'redirect'    => 'redirect-url',
+            'redirect_uri' => 'redirect-url',
 
             // 开放平台 - 第三方平台所需
             'component' => [
@@ -455,7 +456,7 @@ $config = [
         'team_url' => 'https://{your-team}.coding.net',
         'client_id' => 'your app id',
         'client_secret' => 'your app secret',
-        'redirect' => 'redirect URL',
+        'redirect_uri' => 'redirect URL',
     ]
 ];
 ```
@@ -472,7 +473,7 @@ $config = [
         'client_id'     => 'AT******************',
         'client_secret' => 'EK**************',
         'sandbox'      => false,
-        'redirect_url'=>"nativexo://paypalpay",
+        'redirect_uri' => "nativexo://paypalpay",
     ],
 ];
 ```
@@ -490,7 +491,7 @@ $config = [
         'team_id'     => 'XXXXXXXXXX',         // Apple Developer Team ID
         'key_id'      => 'XXXXXXXXXX',         // Key ID from Apple Developer
         'private_key' => file_get_contents('/path/to/AuthKey_XXXXXXXXXX.p8'), // .p8 private key content
-        'redirect'    => 'https://example.com/auth/apple/callback',
+        'redirect_uri' => 'https://example.com/auth/apple/callback',
     ],
 ];
 ```
@@ -508,7 +509,7 @@ $response = $socialite->create('github')
 
 ### Redirect URL
 
-你也可以动态设置' redirect_uri '，你可以使用以下方法来改变 `redirect_uri` URL:
+你也可以动态设置 `redirect_uri`，你可以使用以下方法来改变 `redirect_uri` URL:
 
 ```php
 $url = 'your callback url.';

--- a/README_EN.md
+++ b/README_EN.md
@@ -47,7 +47,7 @@ $config = [
     'github' => [
         'client_id'     => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect'      => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 ];
 
@@ -69,7 +69,7 @@ $config = [
     'github' => [
         'client_id' => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect' => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 ];
 
@@ -89,7 +89,8 @@ $user->getEmail();     // "anzhengchao@gmail.com"
 
 ## Configuration
 
-Each create uses the same configuration keys: `client_id`, `client_secret`, `redirect`.
+Each provider uses the same configuration keys: `client_id`, `client_secret`, `redirect_uri`.
+Legacy aliases are still supported: `redirect`, `redirect_url`.
 
 Example:
 ```php
@@ -97,12 +98,12 @@ $config = [
   'weibo' => [
     'client_id'     => 'your-app-id',
     'client_secret' => 'your-app-secret',
-    'redirect'      => 'http://localhost/socialite/callback.php',
+    'redirect_uri' => 'http://localhost/socialite/callback.php',
   ],
   'facebook' => [
     'client_id'     => 'your-app-id',
     'client_secret' => 'your-app-secret',
-    'redirect'      => 'http://localhost/socialite/callback.php',
+    'redirect_uri' => 'http://localhost/socialite/callback.php',
   ],
 ];
 ```
@@ -117,7 +118,7 @@ $config = [
         'provider' => 'github',  // <-- provider name
         'client_id' => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect' => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
        
     // another github app
@@ -125,7 +126,7 @@ $config = [
         'provider' => 'github',  // <-- provider name
         'client_id' => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect' => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
     //...
 ];
@@ -144,7 +145,7 @@ $config = [
         'provider' => 'myprovider',  // <-- provider name
         'client_id' => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect' => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 ];
 
@@ -176,7 +177,7 @@ $config = [
         'provider' => MyCustomProvider::class,  // <-- class name
         'client_id' => 'your-app-id',
         'client_secret' => 'your-app-secret',
-        'redirect' => 'http://localhost/socialite/callback.php',
+        'redirect_uri' => 'http://localhost/socialite/callback.php',
     ],
 ];
 
@@ -206,8 +207,8 @@ $config = [
     'rsa_private_key' => 'your-rsa-private-key',
 
     // Be sure to set this value and make sure that it is the same address value as set in the official admin system.
-    // This can also be named as 'redirect_url' like the official documentation.
-    'redirect' => 'http://localhost/socialite/callback.php',
+    // Recommended key: 'redirect_uri' (legacy aliases: 'redirect', 'redirect_url')
+    'redirect_uri' => 'http://localhost/socialite/callback.php',
   ]
   ...
 ];
@@ -240,8 +241,8 @@ $config = [
       // or 'app_secret' 
       'client_secret' => 'your app secret',
 
-      // or 'redirect_url'
-      'redirect' => 'redirect URL'
+      // legacy aliases: 'redirect' or 'redirect_url'
+      'redirect_uri' => 'redirect URL'
   ]
 ];
 
@@ -268,7 +269,7 @@ $config = [
 
       'client_secret' => 'your app secret',
 
-      'redirect' => 'redirect URL'
+      'redirect_uri' => 'redirect URL'
   ]
 ];
 
@@ -288,7 +289,7 @@ $config = [
   'toutiao' => [
     'client_id' => 'your app id',
     'client_secret' => 'your app secret',
-    'redirect' => 'redirect URL'
+    'redirect_uri' => 'redirect URL'
   ]
 ];
 
@@ -307,7 +308,7 @@ $config = [
   'xigua' => [
     'client_id' => 'your app id',
     'client_secret' => 'your app secret',
-    'redirect' => 'redirect URL'
+    'redirect_uri' => 'redirect URL'
   ]
 ];
 
@@ -348,8 +349,8 @@ $config = [
         // or 'app_secret' 
         'client_secret' => 'your app secret',
 
-        // or 'redirect_url'
-        'redirect' => 'redirect URL',
+        // legacy aliases: 'redirect' or 'redirect_url'
+        'redirect_uri' => 'redirect URL',
 
         // if you want to use internal way to get app_access_token
         // set this key by 'internal' then you already turn on the internal app mode 
@@ -378,8 +379,8 @@ $config = [
         // or 'app_secret' 
         'client_secret' => 'your app secret',
 
-        // or 'redirect_url'
-        'redirect' => 'redirect URL',
+        // legacy aliases: 'redirect' or 'redirect_url'
+        'redirect_uri' => 'redirect URL',
 
         // if you want to use internal way to get app_access_token
         // set this key by 'internal' then you already turn on the internal app mode 
@@ -416,7 +417,7 @@ You just need input your config like below config. Official Accounts authorizati
         [
             'client_id' => 'client_id',
             'client_secret' => 'client_secret',
-            'redirect' => 'redirect-url',
+            'redirect_uri' => 'redirect-url',
 
             // Open Platform - Third-party Platform Need
             'component' => [
@@ -438,7 +439,7 @@ $config = [
         'team_url' => 'https://{your-team}.coding.net',
         'client_id' => 'your app id',
         'client_secret' => 'your app secret',
-        'redirect' => 'redirect URL',
+        'redirect_uri' => 'redirect URL',
     ]
 ];
 ```
@@ -456,7 +457,7 @@ $config = [
         'client_id'     => 'AT******************',
         'client_secret' => 'EK**************',
         'sandbox'      => false,
-        'redirect_url'=>"nativexo://paypalpay",
+        'redirect_uri' => "nativexo://paypalpay",
     ],
 ];
 ```
@@ -474,7 +475,7 @@ $config = [
         'team_id'     => 'XXXXXXXXXX',         // Apple Developer Team ID
         'key_id'      => 'XXXXXXXXXX',         // Key ID from Apple Developer
         'private_key' => file_get_contents('/path/to/AuthKey_XXXXXXXXXX.p8'), // .p8 private key content
-        'redirect'    => 'https://example.com/auth/apple/callback',
+        'redirect_uri' => 'https://example.com/auth/apple/callback',
     ],
 ];
 ```
@@ -494,7 +495,7 @@ $response = $socialite->create('github')
 
 ### Redirect URL
 
-You may also want to dynamically set `redirect_uri`，you can use the following methods to change the `redirect_uri` URL:
+You may also want to dynamically set `redirect_uri`, you can use the following methods to change the `redirect_uri` URL:
 
 ```php
 $url = 'your callback url.';

--- a/src/Contracts/FactoryInterface.php
+++ b/src/Contracts/FactoryInterface.php
@@ -2,6 +2,8 @@
 
 namespace Overtrue\Socialite\Contracts;
 
+use Overtrue\Socialite\Config;
+
 const ABNF_APP_ID = 'app_id';
 const ABNF_APP_SECRET = 'app_secret';
 const ABNF_OPEN_ID = 'open_id';
@@ -9,7 +11,7 @@ const ABNF_TOKEN = 'token';
 
 interface FactoryInterface
 {
-    public function config(\Overtrue\Socialite\Config $config): self;
+    public function config(Config $config): self;
 
     public function create(string $name): ProviderInterface;
 

--- a/src/Providers/Base.php
+++ b/src/Providers/Base.php
@@ -66,14 +66,20 @@ abstract class Base implements Contracts\ProviderInterface
             }
         }
 
-        // normalize 'redirect_url'
-        if (! $this->config->has('redirect_url')) {
+        // normalize redirect uri aliases to RFC6749_ABNF_REDIRECT_URI
+        if (! $this->config->has(Contracts\RFC6749_ABNF_REDIRECT_URI)) {
             $this->config->set(
-                'redirect_url',
-                $this->config->get('redirect') ?? $this->config->get(Contracts\RFC6749_ABNF_REDIRECT_URI)
+                Contracts\RFC6749_ABNF_REDIRECT_URI,
+                $this->config->get('redirect') ?? $this->config->get('redirect_url')
             );
         }
-        $this->redirectUrl = $this->config->get('redirect_url');
+
+        // keep legacy alias available for compatibility
+        if (! $this->config->has('redirect_url')) {
+            $this->config->set('redirect_url', $this->config->get(Contracts\RFC6749_ABNF_REDIRECT_URI));
+        }
+
+        $this->redirectUrl = $this->config->get(Contracts\RFC6749_ABNF_REDIRECT_URI);
     }
 
     abstract protected function getAuthUrl(): string;
@@ -136,6 +142,8 @@ abstract class Base implements Contracts\ProviderInterface
     public function withRedirectUrl(string $redirectUrl): Contracts\ProviderInterface
     {
         $this->redirectUrl = $redirectUrl;
+        $this->config->set(Contracts\RFC6749_ABNF_REDIRECT_URI, $redirectUrl);
+        $this->config->set('redirect_url', $redirectUrl);
 
         return $this;
     }

--- a/src/Providers/Base.php
+++ b/src/Providers/Base.php
@@ -68,7 +68,10 @@ abstract class Base implements Contracts\ProviderInterface
 
         // normalize 'redirect_url'
         if (! $this->config->has('redirect_url')) {
-            $this->config->set('redirect_url', $this->config->get('redirect'));
+            $this->config->set(
+                'redirect_url',
+                $this->config->get('redirect') ?? $this->config->get(Contracts\RFC6749_ABNF_REDIRECT_URI)
+            );
         }
         $this->redirectUrl = $this->config->get('redirect_url');
     }

--- a/src/Providers/Coding.php
+++ b/src/Providers/Coding.php
@@ -2,10 +2,11 @@
 
 namespace Overtrue\Socialite\Providers;
 
+use GuzzleHttp\Exception\GuzzleException;
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
 use Overtrue\Socialite\Contracts;
-use Overtrue\Socialite\Exceptions;
+use Overtrue\Socialite\Exceptions\BadRequestException;
 use Overtrue\Socialite\Exceptions\InvalidArgumentException;
 use Overtrue\Socialite\User;
 
@@ -66,8 +67,8 @@ class Coding extends Base
     }
 
     /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Overtrue\Socialite\Exceptions\BadRequestException
+     * @throws GuzzleException
+     * @throws BadRequestException
      */
     protected function getUserByToken(string $token): array
     {
@@ -83,7 +84,7 @@ class Coding extends Base
         $response = $this->fromJsonBody($responseInstance);
 
         if (empty($response[Contracts\ABNF_ID])) {
-            throw new Exceptions\BadRequestException((string) $responseInstance->getBody());
+            throw new BadRequestException((string) $responseInstance->getBody());
         }
 
         return $response;

--- a/src/Providers/Google.php
+++ b/src/Providers/Google.php
@@ -21,19 +21,6 @@ class Google extends Base
         'https://www.googleapis.com/auth/userinfo.profile',
     ];
 
-    public function __construct(array $config)
-    {
-        if (
-            !isset($config['redirect_url'])
-            && !isset($config['redirect'])
-            && isset($config[Contracts\RFC6749_ABNF_REDIRECT_URI])
-        ) {
-            $config['redirect_url'] = $config[Contracts\RFC6749_ABNF_REDIRECT_URI];
-        }
-
-        parent::__construct($config);
-    }
-
     protected function getAuthUrl(): string
     {
         return $this->buildAuthUrlFromBase('https://accounts.google.com/o/oauth2/v2/auth');

--- a/src/Providers/Google.php
+++ b/src/Providers/Google.php
@@ -21,6 +21,19 @@ class Google extends Base
         'https://www.googleapis.com/auth/userinfo.profile',
     ];
 
+    public function __construct(array $config)
+    {
+        if (
+            !isset($config['redirect_url'])
+            && !isset($config['redirect'])
+            && isset($config[Contracts\RFC6749_ABNF_REDIRECT_URI])
+        ) {
+            $config['redirect_url'] = $config[Contracts\RFC6749_ABNF_REDIRECT_URI];
+        }
+
+        parent::__construct($config);
+    }
+
     protected function getAuthUrl(): string
     {
         return $this->buildAuthUrlFromBase('https://accounts.google.com/o/oauth2/v2/auth');

--- a/src/Providers/OpenWeWork.php
+++ b/src/Providers/OpenWeWork.php
@@ -86,7 +86,7 @@ class OpenWeWork extends Base
 
         if ($this->detailed) {
             if (empty($user['user_ticket'])) {
-                throw new Exceptions\AuthorizeFailedException('Authorization failed: missing user_ticket in response', $user);
+                throw new AuthorizeFailedException('Authorization failed: missing user_ticket in response', $user);
             }
             $user = \array_merge($user, $this->getUserByTicket($user['user_ticket']));
         }
@@ -151,7 +151,7 @@ class OpenWeWork extends Base
     }
 
     /**
-     * @throws Exceptions\AuthorizeFailedException|GuzzleException
+     * @throws AuthorizeFailedException|GuzzleException
      */
     protected function getUser(string $token, string $code): array
     {
@@ -170,7 +170,7 @@ class OpenWeWork extends Base
         $response = $this->fromJsonBody($responseInstance);
 
         if (($response['errcode'] ?? 1) > 0 || (empty($response['UserId']) && empty($response['openid']))) {
-            throw new Exceptions\AuthorizeFailedException((string) $responseInstance->getBody(), $response);
+            throw new AuthorizeFailedException((string) $responseInstance->getBody(), $response);
         } elseif (empty($response['user_ticket'])) {
             $this->detailed = false;
         }
@@ -179,7 +179,7 @@ class OpenWeWork extends Base
     }
 
     /**
-     * @throws Exceptions\AuthorizeFailedException
+     * @throws AuthorizeFailedException
      * @throws GuzzleException
      */
     protected function getUserByTicket(string $userTicket): array
@@ -199,7 +199,7 @@ class OpenWeWork extends Base
         $response = $this->fromJsonBody($responseInstance);
 
         if (($response['errcode'] ?? 1) > 0 || empty($response['userid'])) {
-            throw new Exceptions\AuthorizeFailedException((string) $responseInstance->getBody(), $response);
+            throw new AuthorizeFailedException((string) $responseInstance->getBody(), $response);
         }
 
         return $response;
@@ -224,7 +224,7 @@ class OpenWeWork extends Base
     }
 
     /**
-     * @throws Exceptions\AuthorizeFailedException
+     * @throws AuthorizeFailedException
      * @throws GuzzleException
      */
     protected function requestSuiteAccessToken(): string
@@ -243,7 +243,7 @@ class OpenWeWork extends Base
         $response = $this->fromJsonBody($responseInstance);
 
         if (isset($response['errcode']) && $response['errcode'] > 0) {
-            throw new Exceptions\AuthorizeFailedException((string) $responseInstance->getBody(), $response);
+            throw new AuthorizeFailedException((string) $responseInstance->getBody(), $response);
         }
 
         return $response['suite_access_token'];

--- a/src/Providers/PayPal.php
+++ b/src/Providers/PayPal.php
@@ -2,8 +2,10 @@
 
 namespace Overtrue\Socialite\Providers;
 
+use GuzzleHttp\Exception\GuzzleException;
 use JetBrains\PhpStorm\Pure;
 use Overtrue\Socialite\Contracts;
+use Overtrue\Socialite\Exceptions\AuthorizeFailedException;
 use Overtrue\Socialite\User;
 
 /**
@@ -93,8 +95,8 @@ class PayPal extends Base
     }
 
     /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Overtrue\Socialite\Exceptions\AuthorizeFailedException
+     * @throws GuzzleException
+     * @throws AuthorizeFailedException
      *
      * @see https://developer.paypal.com/docs/log-in-with-paypal/integrate/#link-getaccesstoken
      */
@@ -118,7 +120,7 @@ class PayPal extends Base
     }
 
     /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws GuzzleException
      *
      * @see https://developer.paypal.com/docs/api/identity/v1/#userinfo_get
      */

--- a/src/Providers/QQ.php
+++ b/src/Providers/QQ.php
@@ -2,6 +2,7 @@
 
 namespace Overtrue\Socialite\Providers;
 
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Utils;
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Pure;
@@ -63,8 +64,8 @@ class QQ extends Base
     }
 
     /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Overtrue\Socialite\Exceptions\AuthorizeFailedException
+     * @throws GuzzleException
+     * @throws AuthorizeFailedException
      */
     protected function getUserByToken(string $token): array
     {

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -41,6 +41,18 @@ class OAuthTest extends TestCase
         $this->assertSame('http://auth.url?client_id=fake_client_id&redirect_uri=fake_redirect&scope=info&response_type=code', $provider->redirect('fake_redirect'));
     }
 
+    public function test_it_can_get_auth_url_with_redirect_uri_config_alias()
+    {
+        $config = [
+            'client_id' => 'fake_client_id',
+            'client_secret' => 'fake_client_secret',
+            'redirect_uri' => 'fake_redirect',
+        ];
+        $provider = new OAuthTestProviderStub($config);
+
+        $this->assertSame('http://auth.url?client_id=fake_client_id&redirect_uri=fake_redirect&scope=info&response_type=code', $provider->redirect());
+    }
+
     public function test_it_can_get_auth_url_with_scopes()
     {
         $config = [

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -38,7 +38,7 @@ class OAuthTest extends TestCase
         $config += ['redirect_url' => 'fake_redirect'];
         $provider = new OAuthTestProviderStub($config);
 
-        $this->assertSame('http://auth.url?client_id=fake_client_id&redirect_uri=fake_redirect&scope=info&response_type=code', $provider->redirect('fake_redirect'));
+        $this->assertSame('http://auth.url?client_id=fake_client_id&redirect_uri=fake_redirect&scope=info&response_type=code', $provider->redirect());
     }
 
     public function test_it_can_get_auth_url_with_redirect_uri_config_alias()
@@ -47,6 +47,18 @@ class OAuthTest extends TestCase
             'client_id' => 'fake_client_id',
             'client_secret' => 'fake_client_secret',
             'redirect_uri' => 'fake_redirect',
+        ];
+        $provider = new OAuthTestProviderStub($config);
+
+        $this->assertSame('http://auth.url?client_id=fake_client_id&redirect_uri=fake_redirect&scope=info&response_type=code', $provider->redirect());
+    }
+
+    public function test_it_can_get_auth_url_with_redirect_config_alias()
+    {
+        $config = [
+            'client_id' => 'fake_client_id',
+            'client_secret' => 'fake_client_secret',
+            'redirect' => 'fake_redirect',
         ];
         $provider = new OAuthTestProviderStub($config);
 

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use GuzzleHttp\Client;
 use Mockery as m;
 use Overtrue\Socialite\Providers\Base;
 use Overtrue\Socialite\User;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 class OAuthTest extends TestCase
 {
@@ -100,8 +103,8 @@ class OAuthTest extends TestCase
             'client_secret' => 'fake_client_secret',
         ];
         $provider = new OAuthTestProviderStub($config);
-        $response = m::mock(\Psr\Http\Message\ResponseInterface::class);
-        $stream = m::mock(\Psr\Http\Message\StreamInterface::class);
+        $response = m::mock(ResponseInterface::class);
+        $stream = m::mock(StreamInterface::class);
 
         $stream->shouldReceive('__toString')->andReturn(\json_encode([
             'access_token' => 'fake_access_token',
@@ -152,8 +155,8 @@ class OAuthTest extends TestCase
         ];
         $provider = new OAuthTestProviderStub($config);
 
-        $response = m::mock(\Psr\Http\Message\ResponseInterface::class);
-        $stream = m::mock(\Psr\Http\Message\StreamInterface::class);
+        $response = m::mock(ResponseInterface::class);
+        $stream = m::mock(StreamInterface::class);
 
         $stream->shouldReceive('__toString')->andReturn(\json_encode([
             'access_token' => 'fake_access_token',
@@ -227,12 +230,12 @@ class OAuthTestProviderStub extends Base
     /**
      * Get a fresh instance of the Guzzle HTTP client.
      */
-    public function getHttpClient(): GuzzleHttp\Client
+    public function getHttpClient(): Client
     {
         if ($this->http) {
             return $this->http;
         }
 
-        return $this->http = m::mock(\GuzzleHttp\Client::class);
+        return $this->http = m::mock(Client::class);
     }
 }

--- a/tests/Providers/DingTalkTest.php
+++ b/tests/Providers/DingTalkTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Overtrue\Socialite\Exceptions\AuthorizeFailedException;
 use Overtrue\Socialite\Exceptions\BadRequestException;
+use Overtrue\Socialite\Exceptions\InvalidArgumentException;
 use Overtrue\Socialite\Providers\DingTalk;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -187,7 +188,7 @@ class DingTalkTest extends TestCase
             'redirect_url' => 'http://localhost/callback',
         ]);
 
-        $this->expectException(\Overtrue\Socialite\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('not supported to get access token.');
 
         $getTokenUrl = new ReflectionMethod(DingTalk::class, 'getTokenUrl');
@@ -203,7 +204,7 @@ class DingTalkTest extends TestCase
             'redirect_url' => 'http://localhost/callback',
         ]);
 
-        $this->expectException(\Overtrue\Socialite\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to use token get User.');
 
         $getUserByToken = new ReflectionMethod(DingTalk::class, 'getUserByToken');

--- a/tests/Providers/GoogleTest.php
+++ b/tests/Providers/GoogleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Providers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Overtrue\Socialite\Providers\Google;
+use PHPUnit\Framework\TestCase;
+use ReflectionObject;
+
+class GoogleTest extends TestCase
+{
+    public function test_google_user_from_code_uses_redirect_uri_config_key()
+    {
+        $provider = new Google([
+            'client_id' => 'client_id',
+            'client_secret' => 'client_secret',
+            'redirect_uri' => 'https://example.com/callback',
+        ]);
+
+        $history = [];
+        $mock = new MockHandler([
+            new Response(200, [], \json_encode([
+                'access_token' => 'test-access-token',
+                'refresh_token' => 'test-refresh-token',
+                'expires_in' => 3600,
+            ])),
+            new Response(200, [], \json_encode([
+                'id' => 'google-user-id',
+                'name' => 'Google User',
+                'email' => 'google@example.com',
+                'picture' => 'https://example.com/avatar.png',
+            ])),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $handler->push(Middleware::history($history));
+        $client = new Client(['handler' => $handler]);
+
+        $reflection = new ReflectionObject($provider);
+        $httpClientProperty = $reflection->getProperty('httpClient');
+        $httpClientProperty->setAccessible(true);
+        $httpClientProperty->setValue($provider, $client);
+
+        $user = $provider->userFromCode('test-code');
+
+        $this->assertSame('google-user-id', $user->getId());
+        $this->assertCount(2, $history);
+
+        \parse_str((string) $history[0]['request']->getBody(), $formParams);
+        $this->assertSame('test-code', $formParams['code'] ?? null);
+        $this->assertSame('https://example.com/callback', $formParams['redirect_uri'] ?? null);
+    }
+}

--- a/tests/Providers/QQTest.php
+++ b/tests/Providers/QQTest.php
@@ -38,13 +38,13 @@ class QQTest extends TestCase
             'redirect_url' => 'http://localhost/callback',
         ]);
 
-        $getTokenUrl = new \ReflectionMethod(QQ::class, 'getTokenUrl');
+        $getTokenUrl = new ReflectionMethod(QQ::class, 'getTokenUrl');
         $getTokenUrl->setAccessible(true);
 
-        $getTokenFields = new \ReflectionMethod(QQ::class, 'getTokenFields');
+        $getTokenFields = new ReflectionMethod(QQ::class, 'getTokenFields');
         $getTokenFields->setAccessible(true);
 
-        $getCodeFields = new \ReflectionMethod(QQ::class, 'getCodeFields');
+        $getCodeFields = new ReflectionMethod(QQ::class, 'getCodeFields');
         $getCodeFields->setAccessible(true);
 
         $this->assertSame('https://graph.qq.com/oauth2.0/token', $getTokenUrl->invoke($provider));

--- a/tests/Providers/WeWorkTest.php
+++ b/tests/Providers/WeWorkTest.php
@@ -229,7 +229,7 @@ class WeWorkTest extends TestCase
             ->getMock();
 
         // Set detailed to true to trigger the UserId validation
-        $detailedProperty = new \ReflectionProperty(WeWork::class, 'detailed');
+        $detailedProperty = new ReflectionProperty(WeWork::class, 'detailed');
         $detailedProperty->setAccessible(true);
         $detailedProperty->setValue($mockProvider, true);
 
@@ -268,7 +268,7 @@ class WeWorkTest extends TestCase
         $client = new Client(['handler' => $handler]);
 
         // Use reflection to set the HTTP client
-        $reflection = new \ReflectionObject($provider);
+        $reflection = new ReflectionObject($provider);
         $httpClientProperty = $reflection->getProperty('httpClient');
         $httpClientProperty->setAccessible(true);
         $httpClientProperty->setValue($provider, $client);
@@ -277,7 +277,7 @@ class WeWorkTest extends TestCase
         $this->expectExceptionMessage('Authorization failed: missing access_token in response');
 
         // Use reflection to test protected method
-        $requestApiAccessToken = new \ReflectionMethod(WeWork::class, 'requestApiAccessToken');
+        $requestApiAccessToken = new ReflectionMethod(WeWork::class, 'requestApiAccessToken');
         $requestApiAccessToken->setAccessible(true);
         $requestApiAccessToken->invoke($provider);
     }
@@ -293,7 +293,7 @@ class WeWorkTest extends TestCase
         $this->expectException(MethodDoesNotSupportException::class);
         $this->expectExceptionMessage('WeWork doesn\'t support access_token mode');
 
-        $getUserByToken = new \ReflectionMethod(WeWork::class, 'getUserByToken');
+        $getUserByToken = new ReflectionMethod(WeWork::class, 'getUserByToken');
         $getUserByToken->setAccessible(true);
         $getUserByToken->invoke($provider, 'test_token');
     }
@@ -307,11 +307,11 @@ class WeWorkTest extends TestCase
         ]);
 
         // Set detailed to true
-        $detailedProperty = new \ReflectionProperty(WeWork::class, 'detailed');
+        $detailedProperty = new ReflectionProperty(WeWork::class, 'detailed');
         $detailedProperty->setAccessible(true);
         $detailedProperty->setValue($provider, true);
 
-        $mapUserToObject = new \ReflectionMethod(WeWork::class, 'mapUserToObject');
+        $mapUserToObject = new ReflectionMethod(WeWork::class, 'mapUserToObject');
         $mapUserToObject->setAccessible(true);
 
         $user = [
@@ -337,7 +337,7 @@ class WeWorkTest extends TestCase
             'redirect' => 'REDIRECT_URI',
         ]);
 
-        $mapUserToObject = new \ReflectionMethod(WeWork::class, 'mapUserToObject');
+        $mapUserToObject = new ReflectionMethod(WeWork::class, 'mapUserToObject');
         $mapUserToObject->setAccessible(true);
 
         $user = [

--- a/tests/Providers/WechatTest.php
+++ b/tests/Providers/WechatTest.php
@@ -1,11 +1,14 @@
 <?php
 
+use GuzzleHttp\Client;
+use Overtrue\Socialite\Contracts\FactoryInterface;
 use Overtrue\Socialite\Exceptions\AuthorizeFailedException;
 use Overtrue\Socialite\Providers\WeChat;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 
 // here we need loaded the symbols first.
-\class_exists(\Overtrue\Socialite\Contracts\FactoryInterface::class);
+\class_exists(FactoryInterface::class);
 
 class WechatTest extends TestCase
 {
@@ -141,7 +144,7 @@ class WechatTest extends TestCase
             ->onlyMethods(['getTokenFromCode', 'fromJsonBody'])
             ->getMock();
 
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
+        $mockResponse = $this->createMock(ResponseInterface::class);
         $mockProvider->method('getTokenFromCode')->willReturn($mockResponse);
 
         // Test missing openid
@@ -175,7 +178,7 @@ class WechatTest extends TestCase
             ->onlyMethods(['getTokenFromCode', 'fromJsonBody'])
             ->getMock();
 
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
+        $mockResponse = $this->createMock(ResponseInterface::class);
         $mockProvider->method('getTokenFromCode')->willReturn($mockResponse);
 
         // Test missing access_token
@@ -198,8 +201,8 @@ class WechatTest extends TestCase
             ->onlyMethods(['getHttpClient', 'fromJsonBody'])
             ->getMock();
 
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
-        $mockHttpClient = $this->createMock(\GuzzleHttp\Client::class);
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockHttpClient = $this->createMock(Client::class);
         $mockHttpClient->method('get')->willReturn($mockResponse);
 
         $mockProvider->method('getHttpClient')->willReturn($mockHttpClient);


### PR DESCRIPTION
## Problem
When users configure OAuth with `redirect_uri` only, token exchange in `userFromCode()` could miss `redirect_uri` in the token request body (for example, Google returning `Missing parameter: redirect_uri`).

## Root Cause
Internal config normalization used legacy aliases (`redirect` / `redirect_url`) as primary sources. If only `redirect_uri` was provided, the provider's internal redirect value could be empty in some flows.

## Fix
The normalization is now done in the base provider so all providers benefit consistently:

1. Normalize legacy aliases to the RFC key `redirect_uri`.
2. Keep `redirect_url` as a compatibility mirror.
3. Use normalized `redirect_uri` as the source for `$this->redirectUrl`.
4. Keep `withRedirectUrl()` in sync by writing both `redirect_uri` and `redirect_url`.

Token exchange already uses base `getTokenFields()`, which sends:

- `code`
- `redirect_uri`

So after normalization, `userFromCode()` token requests include `redirect_uri` automatically.

## Tests
Added/updated tests to prove behavior:

- `tests/Providers/GoogleTest.php::test_google_user_from_code_uses_redirect_uri_config_key`
  - Asserts token POST body includes `redirect_uri=https://example.com/callback` when config only has `redirect_uri`.
- `tests/OAuthTest.php`
  - Added alias coverage for `redirect_uri` and `redirect` in auth URL generation.

## Docs
Updated examples in `README.md` and `README_EN.md` to use `redirect_uri` as the standard key, while documenting `redirect` and `redirect_url` as legacy aliases.

## Validation
Executed locally:

- `vendor/bin/phpunit tests/Providers/GoogleTest.php`
- `vendor/bin/phpunit tests/OAuthTest.php`
- `vendor/bin/phpunit`

All tests pass (existing suite-level warning/deprecation output remains unchanged).
